### PR TITLE
Support "Moving" VS Constraints to code paths

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -290,20 +290,32 @@ class Expander {
   }
 
   consolidateValueSetConstraint(element, value, constraint, previousConstraints) {
-    const target = this.constraintTarget(value, constraint.path);
-    const targetLabel = this.constraintTargetLabel(value, constraint.path);
+    constraint = constraint.clone();
+    let target = this.constraintTarget(value, constraint.path);
+    let targetLabel = this.constraintTargetLabel(value, constraint.path);
 
     let constraints = previousConstraints;
     if (!(target instanceof models.IdentifiableValue)) {
       logger.error('Cannot constrain valueset of %s since it has no identifier', targetLabel);
       return constraints;
     } else if (!this.supportsCodeConstraint(target.identifier)) {
-      logger.error('Cannot constrain valueset of %s since it is not based on code, Coding, or CodeableConcept', targetLabel);
-      return constraints;
-    } else if ((new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).code.hasConstraints) {
+      // Isn't directly a code/Coding/CodeableConcept, so try its value
+      const valID = this.constraintTargetValueIdentifier(value, constraint.path);
+      if (!this.supportsCodeConstraint(valID)) {
+        logger.error('Cannot constrain valueset of %s since neither it nor its value is a code, Coding, or CodeableConcept', targetLabel);
+        return constraints;
+      }
+      // Constraint is on the target's value.  Convert constraint to reference the value explicitly.
+      constraint.path.push(valID);
+      target = this.constraintTarget(value, constraint.path);
+      targetLabel = this.constraintTargetLabel(value, constraint.path);
+    }
+
+    if ((new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).code.hasConstraints) {
       logger.error('Cannot constrain valueset of %s since it is already constrained to a single code', targetLabel);
       return constraints;
     }
+
     const filtered = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).valueSet.constraints;
     for (const previous of filtered) {
       // TODO: We may want to verify that the new valueset is a subset of the old valueset (or that the old valueset allows extension),

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -300,7 +300,18 @@ class Expander {
       return constraints;
     } else if (!this.supportsCodeConstraint(target.identifier)) {
       // Isn't directly a code/Coding/CodeableConcept, so try its value
-      const valID = this.constraintTargetValueIdentifier(value, constraint.path);
+      const targetValue = this.constraintTargetValue(value, constraint.path);
+      let valID = this.valueIdentifier(targetValue);
+      if (typeof valID === 'undefined' && targetValue instanceof models.ChoiceValue) {
+        // It was a choice, so run through the choices looking for one that supports code constraints
+        for (const option of targetValue.aggregateOptions) {
+          if (this.supportsCodeConstraint(option.identifier)) {
+            valID = option.identifier;
+            break;
+          }
+        }
+      }
+
       if (!this.supportsCodeConstraint(valID)) {
         logger.error('Cannot constrain valueset of %s since neither it nor its value is a code, Coding, or CodeableConcept', targetLabel);
         return constraints;
@@ -496,12 +507,16 @@ class Expander {
 
   constraintTargetValueIdentifier(value, path) {
     const targetValue = this.constraintTargetValue(value, path);
-    if (typeof targetValue !== 'undefined') {
+    return this.valueIdentifier(targetValue);
+  }
+
+  valueIdentifier(value) {
+    if (typeof value !== 'undefined') {
       // If target value is a choice, but all the options are the same identifier, return that identifier.
-      if (targetValue instanceof models.ChoiceValue) {
-        const identifier = targetValue.options[0].identifier;
+      if (value instanceof models.ChoiceValue) {
+        const identifier = value.options[0].identifier;
         if (typeof identifier !== 'undefined') {
-          for (const option of targetValue.options) {
+          for (const option of value.options) {
             if (!identifier.equals(option.identifier)) {
               // Mismatched identifiers in choice, so just return (undefined)
               return;
@@ -510,7 +525,7 @@ class Expander {
           return identifier;
         }
       }
-      return targetValue.identifier;
+      return value.identifier;
     }
   }
 


### PR DESCRIPTION
Authors can now simply declare constraints on elements with code-ish values without having to say "with code from", "with CodeableConcept from", etc.  In these cases, we must detect the constraint on the non-code element and move it to its code value.