### PR TITLE
Expand Choice Value Mappings

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -652,26 +652,44 @@ class Expander {
       }
 
       // Go through this mappings rules, resolve the identifiers, and add them to the big rules list
-      for (const mappingRule of map.rules) {
-        const rule = mappingRule.clone();
+      // First clone the rules into a new list because we will possibly insert new rules into it
+      const mappingRules = [...map.rules];
+      for (let i=0; i < mappingRules.length; i++) {
+        const rule = mappingRules[i].clone();
         let valid = true;
         if (rule instanceof models.FieldMappingRule) {
           let currentDE = de;
-          for (let i=0; i < rule.sourcePath.length; i++) {
-            const match = this.findMatchInDataElement(currentDE, rule.sourcePath[i]);
+          for (let j=0; j < rule.sourcePath.length; j++) {
+            let match = this.findMatchInDataElement(currentDE, rule.sourcePath[j]);
+            // If match is an array, then it means the path points to a Value that is a choice.
+            if (Array.isArray(match)) {
+              // We'll process the first of the choices now, but first add the rest of the choice
+              // options to the mappingRules array to be processed later.
+              for (let k=1; k < match.length; k++) {
+                // Get the new source path with the "Value" part replaced by the new match
+                const newSourcePath = rule.sourcePath.slice();
+                newSourcePath[j] = match[k];
+                // Create a clone of the rule with the new sourcepath in it
+                const newRule = new models.FieldMappingRule(newSourcePath, rule.target);
+                // Insert it into the mappingRules for processing later
+                mappingRules.splice(i+k, 0, newRule);
+              }
+              // Now reassign match to the first item in the choice options that matched
+              match = match[0];
+            }
             if (match) {
-              rule.sourcePath[i] = match;
-              if (i < (rule.sourcePath.length-1) && !(match instanceof models.TBD)) {
+              rule.sourcePath[j] = match;
+              if (j < (rule.sourcePath.length-1) && !(match instanceof models.TBD)) {
                 currentDE = this._expanded.dataElements.findByIdentifier(match);
                 if (typeof de === 'undefined') {
-                  logger.error('Cannot resolve data element definition from path: %s', this.highlightPartInPath(rule.sourcePath, i));
+                  logger.error('Cannot resolve data element definition from path: %s', this.highlightPartInPath(rule.sourcePath, j));
                   valid = false;
                   break;
                 }
               }
             } else {
-              if (rule.sourcePath[i].namespace || rule.sourcePath[i].name != 'Value') {
-                logger.error('Cannot resolve data element definition from path: %s', this.highlightPartInPath(rule.sourcePath, i));
+              if (rule.sourcePath[j].namespace || rule.sourcePath[j].name != 'Value') {
+                logger.error('Cannot resolve data element definition from path: %s', this.highlightPartInPath(rule.sourcePath, j));
               }
               valid = false;
               break;
@@ -711,7 +729,6 @@ class Expander {
   }
 
   findMatchInDataElement(de, idToMatch) {
-    let result;
     // Special case logic for TBD (just return the TBD)
     if (idToMatch instanceof models.TBD) {
       return idToMatch.clone();
@@ -719,16 +736,27 @@ class Expander {
     // Special case logic for "Value"
     else if (!idToMatch.namespace && idToMatch.name == 'Value') {
       if (de.value instanceof models.IdentifiableValue) {
-        result = de.value.identifier;
+        return de.value.identifier;
       } else if (typeof de.value === 'undefined') {
         logger.error('Cannot map Value since element does not define a value');
+      } else if (de.value instanceof models.ChoiceValue) {
+        // Return all the possible choices
+        const results = [];
+        for (const opt of de.value.aggregateOptions) {
+          if (opt instanceof models.IdentifiableValue) {
+            results.push(opt.effectiveIdentifier);
+          }
+        }
+        return results;
       } else {
         logger.error('Cannot map Value since it is unsupported type: %s', de.value.constructor.name);
       }
     // Special case logic for "Entry"
     } else if ((!idToMatch.namespace || idToMatch.namespace == 'shr.base') && idToMatch.name == 'Entry') {
       return new models.Identifier('shr.base', 'Entry');
+    // "Normal" case
     } else {
+      let result;
       for (const value of [de.value, ...de.fields]) {
         if (value) {
           const match = this.findMatchInValue(value, idToMatch);
@@ -739,8 +767,8 @@ class Expander {
           }
         }
       }
+      return result;
     }
-    return result;
   }
 
   findMatchInValue(value, idToMatch) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
When a mapping uses the special "Value" word in its path, and that value is actually a choice, we will now expand that into a new mapping rule per choice option.

This is the only way to support mapping choice values as the time, since we don't support passing the special "Value" path down to the fhir exporter.