### PR TITLE
wip: Model inheritance

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -258,6 +258,8 @@ class Expander {
     } else if (newValue instanceof models.ChoiceValue) {
       logger.error('Cannot override %s with %s since overriding ChoiceValue is not supported. ERROR_CODE:12008', oldValue.toString(), newValue.toString());
       return mergedValue;
+    } else if (newValue instanceof models.TBD) {
+      mergedValue.text = newValue.text;
     }
 
     // If the newValue cardinality doesn't match the old value cardinality, it should be a constraint.

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -614,7 +614,7 @@ class Expander {
     let constraints = previousConstraints;
     const filtered = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).includesCode.constraints;
     for (const previous of filtered) {
-      if (this.sameCode(previous.code, constraint.code)) {
+      if (previous.code.equals(constraint.code)) {
         // no need to duplicate the constraint -- just return the existing constraints as-is
         return constraints;
       }
@@ -735,10 +735,6 @@ class Expander {
 
   supportsBooleanConstraint(identifier) {
     return BOOLEAN.equals(identifier);
-  }
-
-  sameCode(c1, c2) {
-    return c1 && c2 && c1.system == c2.system && c1.code == c2.code;
   }
 
   checkHasBaseType(identifier, baseIdentifier) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -58,11 +58,9 @@ class Expander {
       }
     }
     for (const de of this._expanded.dataElements.all) {
-      // TODO: What are the rules for inheriting values from multiple parents? Currently if a value or field matches any parent then it is considered inherited.
       if (de.basedOn && de.basedOn.length) {
         const parents = [];
-        for (let i = 0; i < de.basedOn.length; i += 1) {
-          const basedOn = de.basedOn[i];
+        for (const basedOn of de.basedOn) {
           if (basedOn instanceof models.TBD) {
             logger.debug(`Ignoring TBD parent %s for child element %s.`, basedOn, de.identifier);
             continue;
@@ -78,9 +76,10 @@ class Expander {
           let inheritance = null;
           for (const parent of parents) {
             if (parent.value) {
-              // TODO: This will flag TBD parent values as overridden. Is that the right choice? -jgibson
-              inheritance = models.OVERRIDDEN;
-              if (parent.value.equals(de.value)) {
+              if (!(parent.value instanceof models.TBD)) {
+                inheritance = models.OVERRIDDEN;
+              }
+              if (parent.value.equals(de.value, true)) {
                 inheritance = models.INHERITED;
                 break;
               }
@@ -102,7 +101,7 @@ class Expander {
             });
             if (i >= 0) {
               inheritance = models.OVERRIDDEN;
-              if (field.equals(parent.fields[i])) {
+              if (field.equals(parent.fields[i], true)) {
                 inheritance = models.INHERITED;
                 break;
               }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -43,6 +43,70 @@ class Expander {
         this.expandElement(de);
       }
     }
+
+    const entryDE = this._expanded.dataElements.find('shr.base', 'Entry');
+    let entryFields = null;
+    if (!entryDE) {
+      logger.warn('Could not find expanded definition of shr.base.Entry. Inheritance calculations will be incomplete.');
+      entryFields = {
+        'shr.core': { 'Version': true },
+        'shr.base': {}
+      };
+      for (const name of ['ShrId', 'EntryId', 'EntryType', 'FocalSubject', 'SubjectIsThirdPartyFlag', 'Narrative',
+        'Informant', 'Author', 'AssociatedEncounter', 'OriginalCreationDate', 'LastUpdateDate', 'Language']) {
+        entryFields['shr.base'][name] = true;
+      }
+    }
+    for (const de of this._expanded.dataElements.all) {
+      if (de.basedOn && de.basedOn.length) {
+        const parent = this._expanded.dataElements.findByIdentifier(de.basedOn[0]);
+        if (de.value && parent.value) {
+          if (!parent.value.equals(de.value)) {
+            de.value.inheritance = models.OVERRIDDEN;
+          } else {
+            de.value.inheritance = models.INHERITED;
+          }
+        }
+        for (const field of de.fields) {
+          const i = parent.fields.findIndex(item => {
+            return item instanceof models.IdentifiableValue && (item.identifier.equals(field.identifier) || item.effectiveIdentifier.equals(field.identifier));
+          });
+          if (i >= 0) {
+            if (!field.equals(parent.fields[i])) {
+              field.inheritance = models.OVERRIDDEN;
+            } else {
+              field.inheritance = models.INHERITED;
+            }
+          }
+        }
+      }
+      if (de.isEntry) {
+        if (!entryDE) {
+          for (const field of de.fields) {
+            if (entryFields[field.identifier.namespace] && entryFields[field.identifier.namespace][field.identifier.name]) {
+              logger.error('Could not find expanded definition of shr.base.Entry. Inheritance calculations for %s will be incomplete.', de.identifier);
+              break;
+            }
+          }
+        } else {
+          for (const field of entryDE.fields) {
+            const i = de.fields.findIndex(item => {
+              return item instanceof models.IdentifiableValue && (item.identifier.equals(field.identifier) || item.effectiveIdentifier.equals(field.identifier));
+            });
+            if (i >= 0) {
+              if (!de.fields[i].inheritance) {
+                if (!field.equals(de.fields[i])) {
+                  de.fields[i].inheritance = models.OVERRIDDEN;
+                } else {
+                  de.fields[i].inheritance = models.INHERITED;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     // Now expand all of the mappings
     for (const target of this._unexpanded.maps.targets) {
       for (const de of this._expanded.dataElements.all) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -60,11 +60,25 @@ class Expander {
     for (const de of this._expanded.dataElements.all) {
       // TODO: What are the rules for inheriting values from multiple parents? Currently if a value or field matches any parent then it is considered inherited.
       if (de.basedOn && de.basedOn.length) {
-        const parents = de.basedOn.map((basedOn) => this._expanded.dataElements.findByIdentifier(basedOn));
+        const parents = [];
+        for (let i = 0; i < de.basedOn.length; i += 1) {
+          const basedOn = de.basedOn[i];
+          if (basedOn instanceof models.TBD) {
+            logger.debug(`Ignoring TBD parent %s for child element %s.`, basedOn, de.identifier);
+            continue;
+          }
+          const parent = this._expanded.dataElements.findByIdentifier(basedOn);
+          if (!parent) {
+            logger.error(`Could not find based on element %s for child element %s.`, basedOn, de.identifier);
+          } else {
+            parents.push(parent);
+          }
+        }
         if (de.value) {
           let inheritance = null;
           for (const parent of parents) {
             if (parent.value) {
+              // TODO: This will flag TBD parent values as overridden. Is that the right choice? -jgibson
               inheritance = models.OVERRIDDEN;
               if (parent.value.equals(de.value)) {
                 inheritance = models.INHERITED;
@@ -77,6 +91,10 @@ class Expander {
           }
         }
         for (const field of de.fields) {
+          if (field instanceof models.TBD) {
+            // You can't track inheritance for a TBD field because there is no name associated with it.
+            continue;
+          }
           let inheritance = null;
           for (const parent of parents) {
             const i = parent.fields.findIndex(item => {
@@ -98,6 +116,10 @@ class Expander {
       if (de.isEntry) {
         if (!entryDE) {
           for (const field of de.fields) {
+            if (field instanceof models.TBD) {
+              // You can't track inheritance for a TBD field because there is no name associated with it.
+              continue;
+            }
             if (entryFields[field.identifier.namespace] && entryFields[field.identifier.namespace][field.identifier.name]) {
               logger.error('Could not find expanded definition of shr.base.Entry. Inheritance calculations for %s will be incomplete.', de.identifier);
               break;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -58,25 +58,40 @@ class Expander {
       }
     }
     for (const de of this._expanded.dataElements.all) {
+      // TODO: What are the rules for inheriting values from multiple parents? Currently if a value or field matches any parent then it is considered inherited.
       if (de.basedOn && de.basedOn.length) {
-        const parent = this._expanded.dataElements.findByIdentifier(de.basedOn[0]);
-        if (de.value && parent.value) {
-          if (!parent.value.equals(de.value)) {
-            de.value.inheritance = models.OVERRIDDEN;
-          } else {
-            de.value.inheritance = models.INHERITED;
+        const parents = de.basedOn.map((basedOn) => this._expanded.dataElements.findByIdentifier(basedOn));
+        if (de.value) {
+          let inheritance = null;
+          for (const parent of parents) {
+            if (parent.value) {
+              inheritance = models.OVERRIDDEN;
+              if (parent.value.equals(de.value)) {
+                inheritance = models.INHERITED;
+                break;
+              }
+            }
+          }
+          if (inheritance) {
+            de.value.inheritance = inheritance;
           }
         }
         for (const field of de.fields) {
-          const i = parent.fields.findIndex(item => {
-            return item instanceof models.IdentifiableValue && (item.identifier.equals(field.identifier) || item.effectiveIdentifier.equals(field.identifier));
-          });
-          if (i >= 0) {
-            if (!field.equals(parent.fields[i])) {
-              field.inheritance = models.OVERRIDDEN;
-            } else {
-              field.inheritance = models.INHERITED;
+          let inheritance = null;
+          for (const parent of parents) {
+            const i = parent.fields.findIndex(item => {
+              return item instanceof models.IdentifiableValue && (item.identifier.equals(field.identifier) || item.effectiveIdentifier.equals(field.identifier));
+            });
+            if (i >= 0) {
+              inheritance = models.OVERRIDDEN;
+              if (field.equals(parent.fields[i])) {
+                inheritance = models.INHERITED;
+                break;
+              }
             }
+          }
+          if (inheritance) {
+            field.inheritance = inheritance;
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.1.0",
+  "version": "5.2.0-beta.1",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "https://github.com/standardhealth/shr-models#model-inheritance"
+    "shr-models": "^5.2.0-beta.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.1.0"
+    "shr-models": "https://github.com/standardhealth/shr-models#model-inheritance"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -78,7 +78,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.description).to.be.undefined;
     expect(eSubA.concepts).to.be.empty;
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1));
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -101,7 +101,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.description).to.equal('It is SubA.');
     expect(eSubA.concepts).to.eql([new models.Concept('http://foo.org', 'baz')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1));
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -119,7 +119,7 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1));
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'SubAFieldA')).withMinMax(1, 1)
     ]);
@@ -139,7 +139,7 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1));
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -158,7 +158,7 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.be.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1));
+    expect(eSubA.value).to.be.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -229,7 +229,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
-      new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1),
+      new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1).withInheritance(models.INHERITED),
       new models.IdentifiableValue(id('shr.test', 'SubAFieldA')).withMinMax(1, 1)
     ]);
   });
@@ -275,6 +275,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 5)
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 3)))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -300,6 +301,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 5)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
   // Invalid Cardinality Constraints
@@ -321,6 +323,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1) // No constraint since it was invalid
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -350,6 +353,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'AVal')).withMinMax(0, 1) // No constraint since it was invalid
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -380,6 +384,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'AVal')).withMinMax(0, 1)
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])) // Last valid constraint
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -402,6 +407,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1) // retain base cardinality
+        .withInheritance(models.INHERITED)
     ]);
   });
 
@@ -431,6 +437,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AField')).withMinMax(0, 1) // No constraint since it was invalid
+        .withInheritance(models.INHERITED)
     ]);
   });
 
@@ -461,6 +468,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AField')).withMinMax(0, 1)
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])) // Last valid constraint
+        .withInheritance(models.INHERITED)
     ]);
   });
 
@@ -490,6 +498,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -574,6 +583,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB')))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -628,7 +638,7 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
-      new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)); // No constraint since it was invalid
+      new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint since it was invalid
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -662,6 +672,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))) // Original constraint
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -691,6 +702,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1) // No constraint since it was invalid
+        .withInheritance(models.INHERITED)
     ]);
 
   });
@@ -726,6 +738,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))) // Original constraint
+        .withInheritance(models.INHERITED)
     ]);
   });
 
@@ -812,6 +825,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
         .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritance(models.OVERRIDDEN)
     );
   });
 
@@ -839,6 +853,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
         .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritance(models.INHERITED)
     );
   });
 
@@ -874,7 +889,8 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))]
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritance(models.OVERRIDDEN)]
     );
   });
 
@@ -905,6 +921,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
         .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritance(models.OVERRIDDEN)
     );
   });
 
@@ -931,7 +948,8 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))]
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritance(models.INHERITED)]
     );
   });
 
@@ -1213,6 +1231,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org'))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1240,6 +1259,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1267,6 +1287,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1295,6 +1316,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -1319,6 +1341,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org'))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -1397,7 +1420,7 @@ describe('#expand()', () => {
     const eSubB = findExpanded('shr.test', 'SubB');
     expect(eSubB.identifier).to.eql(id('shr.test', 'SubB'));
     expect(eSubB.basedOn).to.eql([id('shr.test', 'B')]);
-    expect(eSubB.value).to.eql(new models.IdentifiableValue(pid('code')).withMinMax(0, 1)); // No constraint
+    expect(eSubB.value).to.eql(new models.IdentifiableValue(pid('code')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
     expect(eSubB.fields).to.be.empty;
   });
 
@@ -1448,7 +1471,7 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1)); // No constraint
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -1476,6 +1499,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1500,7 +1524,7 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
-    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1)]); // No constraint
+    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1).withInheritance(models.INHERITED)]); // No constraint
   });
 
   it('should report an error when putting a valueset constraint on a field already constrained to a code', () => {
@@ -1528,6 +1552,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.INHERITED)
     ]);
   });
 
@@ -1553,6 +1578,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1585,6 +1611,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org/valueset'))
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1656,6 +1683,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1683,6 +1711,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1710,6 +1739,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1764,6 +1794,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -1813,6 +1844,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -1840,6 +1872,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.INHERITED)
     ]);
   });
 
@@ -1863,7 +1896,7 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1)); // No constraint
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -1887,7 +1920,7 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
-    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1)]); // No constraint
+    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1).withInheritance(models.INHERITED)]); // No constraint
   });
 
     // Valid Includes Code Constraints
@@ -1912,6 +1945,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1944,6 +1978,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org/valueset'))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2016,6 +2051,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2044,6 +2080,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2071,6 +2108,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2096,6 +2134,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -2146,6 +2185,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritance(models.OVERRIDDEN)
     ]);
   });
 
@@ -2173,6 +2213,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritance(models.INHERITED)
     ]);
   });
 
@@ -2196,7 +2237,7 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1)); // No constraint
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1).withInheritance(models.INHERITED)); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -2220,7 +2261,7 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
-    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1)]); // No constraint
+    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1).withInheritance(models.INHERITED)]); // No constraint
   });
 
   // Valid Boolean Constraints
@@ -2245,6 +2286,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
         .withConstraint(new models.BooleanConstraint(true))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2294,6 +2336,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
         .withConstraint(new models.BooleanConstraint(false))
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2324,6 +2367,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
         .withConstraint(new models.BooleanConstraint(true))
+        .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2346,7 +2390,7 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1)); // No constraint
+    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 });

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -3,12 +3,14 @@ const {expand, setLogger} = require('../index');
 const models = require('shr-models');
 const err = require('shr-test-helpers/errors');
 
-// Set the logger -- this is needed for detecting and checking errors
-setLogger(err.logger());
-
 let _specs, _result;
 
 describe('#expand()', () => {
+  before(function() {
+    // Set the logger -- this is needed for detecting and checking errors
+    setLogger(err.logger());
+  });
+
   beforeEach(function() {
     err.clear();
     _specs = new models.Specifications();

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -180,6 +180,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
         .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0)))
+        .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
   });
@@ -208,6 +209,7 @@ describe('#expand()', () => {
           .withOption(new models.IdentifiableValue(pid('string')))
           .withOption(new models.IdentifiableValue(pid('code')))
         .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0)))
+        .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
   });
@@ -253,6 +255,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1)))
+        .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1447,6 +1450,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(1, 1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')]))
+        .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
   });
@@ -1769,6 +1773,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(1, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+        .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
   });

--- a/test/map-expand-test.js
+++ b/test/map-expand-test.js
@@ -19,6 +19,9 @@ describe('#expandMap()', () => {
     // A core namespace and Coding data element needed by some tests
     _specs.namespaces.add(new models.Namespace('shr.core'));
     _specs.dataElements.add(new models.DataElement(id('shr.core', 'Coding'), false));
+    // A degenerate shr.base.Entry is needed to avoid warnings, which are considered illegal in this test.
+    _specs.namespaces.add(new models.Namespace('shr.base'));
+    _specs.dataElements.add(new models.DataElement(id('shr.base', 'Entry'), false));
   });
 
   afterEach(function() {

--- a/test/map-expand-test.js
+++ b/test/map-expand-test.js
@@ -15,7 +15,7 @@ describe('#expandMap()', () => {
     err.clear();
     _specs = new models.Specifications();
     // The SHR test namespace used by most tests
-    _specs.namespaces.add(new models.Namespace('shr.core'));
+    _specs.namespaces.add(new models.Namespace('shr.test'));
     // A core namespace and Coding data element needed by some tests
     _specs.namespaces.add(new models.Namespace('shr.core'));
     _specs.dataElements.add(new models.DataElement(id('shr.core', 'Coding'), false));

--- a/test/map-expand-test.js
+++ b/test/map-expand-test.js
@@ -3,12 +3,14 @@ const {expand, setLogger} = require('../index');
 const models = require('shr-models');
 const err = require('shr-test-helpers/errors');
 
-// Set the logger -- this is needed for detecting and checking errors
-setLogger(err.logger('warn'));
-
 let _specs, _result;
 
 describe('#expandMap()', () => {
+  before(function() {
+    // Set the logger -- this is needed for detecting and checking errors
+    setLogger(err.logger('warn'));
+  });
+
   beforeEach(function() {
     err.clear();
     _specs = new models.Specifications();

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,10 @@ shr-models@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
 
+"shr-models@https://github.com/standardhealth/shr-models#model-inheritance":
+  version "5.1.0"
+  resolved "https://github.com/standardhealth/shr-models#6e7d731f95f4208592a952a7f44913614400fee0"
+
 shr-test-helpers@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.1.tgz#72abffcf26606fd5d88f731e3c3d4833210f9d1e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,7 +887,7 @@ shr-models@^5.1.0:
 
 "shr-models@https://github.com/standardhealth/shr-models#model-inheritance":
   version "5.1.0"
-  resolved "https://github.com/standardhealth/shr-models#6e7d731f95f4208592a952a7f44913614400fee0"
+  resolved "https://github.com/standardhealth/shr-models#2951eba68159ee5892aa453f26afc2208094f75b"
 
 shr-test-helpers@^5.0.1:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,9 +885,9 @@ shr-models@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
 
-"shr-models@https://github.com/standardhealth/shr-models#model-inheritance":
-  version "5.1.0"
-  resolved "https://github.com/standardhealth/shr-models#2951eba68159ee5892aa453f26afc2208094f75b"
+shr-models@^5.2.0-beta.1:
+  version "5.2.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0-beta.1.tgz#7c2f4c42a44716dd8ea8288fec226512d15f0d38"
 
 shr-test-helpers@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
This adds support for tracking inheritance of fields and values to shr-expand. This adds another pass after the expansion to compare the fields and values of each child element against its parents. If a field or value exists on at least one parent and it is equal to the child's copy then it is considered `inherited`. If it is not equal to any parent's copy then it is considered `overridden`. If the field or value does not exist on the parent then it is considered to be new and the `inheritance` field is left null/undefined.

Note that AFAICT the none of the spec uses multiple inheritance (and I don't think that any of our tests really exercise it) so I'm not sure how it will behave when using that language feature.

One outstanding issue is the inheritance of Entry fields. I think it is because the expander special-cases inheritance from shr.base.Entry in findMatchInDataElement().