### PR TITLE
Implemented sanity checking for conflicting versions of shr-models

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1027,4 +1027,4 @@ class Expander {
   }
 }
 
-module.exports = { expand, setLogger };
+module.exports = { expand, setLogger, MODELS_INFO: models.MODELS_INFO };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.2.0-beta.1",
+  "version": "5.2.0",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.2.0-beta.1"
+    "shr-models": "^5.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,9 +885,9 @@ shr-models@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
 
-shr-models@^5.2.0-beta.1:
-  version "5.2.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0-beta.1.tgz#7c2f4c42a44716dd8ea8288fec226512d15f0d38"
+shr-models@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0.tgz#3dba6f113f65a16250de2012f6e4d4bbf692e0ed"
 
 shr-test-helpers@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Added sanity checking support for different versions of `shr-models`. Note that although `shr-expand` uses `shr-test-helpers` as a dev dependency, it doesn't actually use the export portion of test-helpers, so it hasn't been bumped.