### PR TITLE
Fix logging and path resolution

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -221,7 +221,7 @@ class Expander {
       return expanded;
     } finally {
       logger.debug('Done expanding element');
-      this.logger = lastLogger;
+      logger = lastLogger;
     }
   }
 
@@ -925,7 +925,7 @@ class Expander {
       return merged;
     } finally {
       logger.debug('Done expanding mapping');
-      this.logger = lastLogger;
+      logger = lastLogger;
     }
   }
 

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -937,7 +937,7 @@ class Expander {
     // Special case logic for "Value"
     else if (!idToMatch.namespace && idToMatch.name == 'Value') {
       if (de.value instanceof models.IdentifiableValue) {
-        return de.value.identifier;
+        return de.value.effectiveIdentifier;
       } else if (typeof de.value === 'undefined') {
         logger.error('Cannot map Value since element does not define a value. ERROR_CODE:12033');
       } else if (de.value instanceof models.ChoiceValue) {
@@ -975,9 +975,9 @@ class Expander {
   findMatchInValue(value, idToMatch) {
     if (value instanceof models.IdentifiableValue) {
       if (idToMatch.namespace && (value.identifier.equals(idToMatch)) || value.effectiveIdentifier.equals(idToMatch)) {
-        return value.identifier.clone();
+        return value.effectiveIdentifier.clone();
       } else if (!idToMatch.namespace && (value.identifier.name == idToMatch.name || value.effectiveIdentifier.name == idToMatch.name)) {
-        return value.identifier.clone();
+        return value.effectiveIdentifier.clone();
       }
     } else if (value instanceof models.ChoiceValue) {
       for (const opt of value.options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Addresses #14 by resolving mapping paths using `effectiveIdentifier`.

Also fixes a bug in the logger usage that was not correctly re-assigning the last logger.

Prior to this fix, running the following command on the shr_spec shimi branch:
```
node . ../shr_spec/ -l error | grep ActionContext
```
would result in:
```
[14:38:18.935Z] ERROR shr: Cannot resolve data element definition from path: ActionContext.<<OccurrenceTimeOrPeriod>>. ERROR_CODE:12032 (module=shr-expand, shrId=shr.base.Any, targetSpec=FHIR_STU_3)
[14:38:18.936Z] ERROR shr: Cannot resolve data element definition from path: ActionContext.<<Annotation>>. ERROR_CODE:12032 (module=shr-expand, shrId=shr.base.Any, targetSpec=FHIR_STU_3)
```

With the fix, the grep comes back empty.

NOTE: You probaly also have to update the `DeviceUsed` mapping to from:
```
ActionContext.OccurrenceTimeOrPeriod maps to whenUsed
```
to
```
PerformedContext.OccurrenceTimeOrPeriod maps to whenUsed
```