### PR TITLE
Make shr-models and bunyan peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,16 @@
     "lint": "./node_modules/.bin/eslint .",
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },
-  "dependencies": {
-    "bunyan": "^1.8.9",
-    "shr-models": "^5.2.0"
-  },
   "devDependencies": {
+    "bunyan": "^1.8.9",
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-test-helpers": "^5.0.1"
+    "shr-models": "^5.2.1",
+    "shr-test-helpers": "^5.1.1"
+  },
+  "peerDependencies": {
+    "bunyan": "^1.8.9",
+    "shr-models": "^5.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,8 +91,8 @@ buffer-shims@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
 bunyan@^1.8.9:
-  version "1.8.9"
-  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.9.tgz#2c7c9d422ea64ee2465d52b4decd72de0657401a"
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
   optionalDependencies:
     dtrace-provider "~0.8"
     moment "^2.10.6"
@@ -223,8 +223,8 @@ doctrine@^1.2.2:
     isarray "^1.0.0"
 
 dtrace-provider@~0.8:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.1.tgz#cd4d174a233bea1bcf4a1fbfa5798f44f48cda9f"
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.5.tgz#98ebba221afac46e1c39fd36858d8f9367524b92"
   dependencies:
     nan "^2.3.3"
 
@@ -693,8 +693,8 @@ mocha@^3.2.0:
     supports-color "3.1.2"
 
 moment@^2.10.6:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+  version "2.19.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#bdb99d270d6d7fda78cc0fbace855e27fe7da69f"
 
 ms@0.7.1:
   version "0.7.1"
@@ -717,8 +717,8 @@ mv@~2:
     rimraf "~2.4.0"
 
 nan@^2.3.3:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -881,20 +881,13 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
+shr-models@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.1.tgz#23108d369a0be9fa2518d9be4c1e53685d9dd776"
 
-shr-models@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0.tgz#3dba6f113f65a16250de2012f6e4d4bbf692e0ed"
-
-shr-test-helpers@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.1.tgz#72abffcf26606fd5d88f731e3c3d4833210f9d1e"
-  dependencies:
-    bunyan "^1.8.9"
-    shr-models "^5.1.0"
+shr-test-helpers@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.1.1.tgz#e649cab3685f76bd25eca590d0949fd162b43f9f"
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Due to the nature of the SHR tools, the entire chain must be guaranteed to be using the same instance of the shr-models library.  This has caused issues in the past and required every component of the chain to be updated and re-published whenever shr-models changed in any way.  A better approach to this is to declare shr-models as a peer dependency and rely on the end-user application to bring in the single instance of shr-models.

Bunyan is used in a similar way, and thus also declared a peer dependency.

In order to run the tests, however, these libararies need to be available, so they've also been added as dev dependencies.
