### PR TITLE
Error code updates

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -190,7 +190,7 @@ class Expander {
             // Still need to process the cardinality and constraints to ensure they are valid
             // (test for node == element to ensure we only report out the error on the root element)
             if (typeof mergedValue.effectiveCard === 'undefined' && node == element) {
-              logger.error('No cardinality found for value: %s. ERROR_CODE:12003', mergedValue.toLoggerString());
+              logger.error('No cardinality found for value: %s. ERROR_CODE:12003', mergedValue.toString());
             }
             mergedValue.constraints = this.consolidateConstraints(node, mergedValue);
           }
@@ -206,7 +206,7 @@ class Expander {
             // Still need to process the cardinality and constraints to ensure they are valid
             // (test for node == element to ensure we only report out the error on the root element)
             if (typeof f.effectiveCard === 'undefined' && node == element) {
-              logger.error('No cardinality found for field %s in %s. ERROR_CODE:12004', (f.identifier) ? f.identifier.name : f.toLoggerString(), element.identifier.name);
+              logger.error('No cardinality found for field %s in %s. ERROR_CODE:12004', f.toString(), element.identifier.name);
             }
             f.constraints = this.consolidateConstraints(node, f);
             mergedFields.push(f);
@@ -233,7 +233,7 @@ class Expander {
 
     // Check that the class types match (except when new one is IncompleteValue or old one is a choice).  An error abandons the merge.
     if (!(newValue instanceof models.IncompleteValue) && !(oldValue instanceof models.ChoiceValue) && newValue.constructor.name != oldValue.constructor.name) {
-      logger.error('Cannot override %s with %s. ERROR_CODE:12005', oldValue.toLoggerString(), newValue.toLoggerString());
+      logger.error('Cannot override %s with %s. ERROR_CODE:12005', oldValue.toString(), newValue.toString());
       return mergedValue;
     }
 
@@ -245,17 +245,17 @@ class Expander {
           // The newValue must be one of the choices
           const match = this.findMatchingOption(oldValue, newValue);
           if (!match) {
-            logger.error('Cannot override %s with %s since it is not one of the options. ERROR_CODE:12006', oldValue.toLoggerString(), newValue.toLoggerString());
+            logger.error('Cannot override %s with %s since it is not one of the options. ERROR_CODE:12006', oldValue.toString(), newValue.toString());
             return mergedValue;
           }
           mergedValue = match.clone().withCard(oldValue.card.clone()); // Take on the choice's cardinality
         } else if (!newValue.identifier.equals(oldValue.identifier) && !newValue.identifier.equals(oldValue.effectiveIdentifier)) {
-          logger.error('Cannot override %s with %s. ERROR_CODE:12007', oldValue.toLoggerString(), newValue.toLoggerString());
+          logger.error('Cannot override %s with %s. ERROR_CODE:12007', oldValue.toString(), newValue.toString());
           return mergedValue;
         }
       }
     } else if (newValue instanceof models.ChoiceValue) {
-      logger.error('Cannot override %s with %s since overriding ChoiceValue is not supported. ERROR_CODE:12008', oldValue.toLoggerString(), newValue.toLoggerString());
+      logger.error('Cannot override %s with %s since overriding ChoiceValue is not supported. ERROR_CODE:12008', oldValue.toString(), newValue.toString());
       return mergedValue;
     } else if (newValue instanceof models.TBD) {
       mergedValue.text = newValue.text;
@@ -390,7 +390,7 @@ class Expander {
         continue;
       }
       if (!this.checkHasBaseType(constraint.isA, previous.isA)) {
-        logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toLoggerString(), previous.isA.toString(), constraint.isA.toString());
+        logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toString(), previous.isA.toString(), constraint.isA.toString());
         return constraints;
       }
       // Remove the previous type constraint since this one supercedes it

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -190,7 +190,7 @@ class Expander {
             // Still need to process the cardinality and constraints to ensure they are valid
             // (test for node == element to ensure we only report out the error on the root element)
             if (typeof mergedValue.effectiveCard === 'undefined' && node == element) {
-              logger.error('No cardinality found for value: %s. ERROR_CODE:12003', mergedValue.toString());
+              logger.error('No cardinality found for value: %s. ERROR_CODE:12003', mergedValue.toLoggerString());
             }
             mergedValue.constraints = this.consolidateConstraints(node, mergedValue);
           }
@@ -206,7 +206,7 @@ class Expander {
             // Still need to process the cardinality and constraints to ensure they are valid
             // (test for node == element to ensure we only report out the error on the root element)
             if (typeof f.effectiveCard === 'undefined' && node == element) {
-              logger.error('No cardinality found for field: %s. ERROR_CODE:12004', f.toString());
+              logger.error('No cardinality found for field %s in %s. ERROR_CODE:12004', (f.identifier) ? f.identifier.name : f.toLoggerString(), element.identifier.name);
             }
             f.constraints = this.consolidateConstraints(node, f);
             mergedFields.push(f);
@@ -233,7 +233,7 @@ class Expander {
 
     // Check that the class types match (except when new one is IncompleteValue or old one is a choice).  An error abandons the merge.
     if (!(newValue instanceof models.IncompleteValue) && !(oldValue instanceof models.ChoiceValue) && newValue.constructor.name != oldValue.constructor.name) {
-      logger.error('Cannot override %s with %s. ERROR_CODE:12005', oldValue.toString(), newValue.toString());
+      logger.error('Cannot override %s with %s. ERROR_CODE:12005', oldValue.toLoggerString(), newValue.toLoggerString());
       return mergedValue;
     }
 
@@ -245,17 +245,17 @@ class Expander {
           // The newValue must be one of the choices
           const match = this.findMatchingOption(oldValue, newValue);
           if (!match) {
-            logger.error('Cannot override %s with %s since it is not one of the options. ERROR_CODE:12006', oldValue.toString(), newValue.toString());
+            logger.error('Cannot override %s with %s since it is not one of the options. ERROR_CODE:12006', oldValue.toLoggerString(), newValue.toLoggerString());
             return mergedValue;
           }
           mergedValue = match.clone().withCard(oldValue.card.clone()); // Take on the choice's cardinality
         } else if (!newValue.identifier.equals(oldValue.identifier) && !newValue.identifier.equals(oldValue.effectiveIdentifier)) {
-          logger.error('Cannot override %s with %s. ERROR_CODE:12007', oldValue.toString(), newValue.toString());
+          logger.error('Cannot override %s with %s. ERROR_CODE:12007', oldValue.toLoggerString(), newValue.toLoggerString());
           return mergedValue;
         }
       }
     } else if (newValue instanceof models.ChoiceValue) {
-      logger.error('Cannot override %s with %s since overriding ChoiceValue is not supported. ERROR_CODE:12008', oldValue.toString(), newValue.toString());
+      logger.error('Cannot override %s with %s since overriding ChoiceValue is not supported. ERROR_CODE:12008', oldValue.toLoggerString(), newValue.toLoggerString());
       return mergedValue;
     } else if (newValue instanceof models.TBD) {
       mergedValue.text = newValue.text;
@@ -390,7 +390,7 @@ class Expander {
         continue;
       }
       if (!this.checkHasBaseType(constraint.isA, previous.isA)) {
-        logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toString(), previous.isA.toString(), constraint.isA.toString());
+        logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toLoggerString(), previous.isA.toString(), constraint.isA.toString());
         return constraints;
       }
       // Remove the previous type constraint since this one supercedes it


### PR DESCRIPTION
reference: https://github.com/standardhealth/shr-models/pull/17

This is a more readable option for choice values in errors (in response to feedback from Mark). 

Turns:

> [19:25:20.965Z] ERROR shr: No cardinality found for field: ChoiceValue<IdentifiableValue<shr.core.CodeableConcept>|RefValue<shr.core.Range>|IdentifiableValue<shr.core.Quantity>>. ERROR_CODE:12004 (module=shr-expand, shrId=shr.careplan.ResultTargeted)


into:

> [19:19:23.316Z] ERROR shr: No cardinality found for field Choice(CodeableConcept, Range, Quantity) in ResultTargeted. ERROR_CODE:12004 (module=shr-expand, shrId=shr.careplan.ResultTargeted)


(with the addition of some base class tracking improvements by @cmoesel).
