### PR TITLE
Don't inherit from mismatched targets

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -838,8 +838,9 @@ class Expander {
           } else if (targetItem != base.targetItem) {
             const ok = this._exporterMap.has(map.targetSpec) && this._exporterMap.get(map.targetSpec).isTargetBasedOn(targetItem, base.targetItem);
             if (!ok) {
-              logger.warn('Potentially mismatched targets: %s maps to %s, but based on class (%s) maps to %s, and %s is not based on %s in %s. ERROR_CODE:02001',
+              logger.debug('Skipping mismatched targets: %s maps to %s, but based on class (%s) maps to %s, and %s is not based on %s in %s. ERROR_CODE:02001',
                 identifier.fqn, targetItem, base.identifier.fqn, base.targetItem, targetItem, base.targetItem, map.targetSpec);
+              continue;
             }
           }
           // Push the rules onto our list, but clone them first (just for safety)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -2535,8 +2535,8 @@ function add(...dataElements) {
 }
 
 // Expands the current specs and stores results in _result
-function doExpand() {
-  _result = expand(_specs);
+function doExpand(...exporters) {
+  _result = expand(_specs, ...exporters);
 }
 
 function findExpanded(namespace, name) {


### PR DESCRIPTION
If `Foo` maps to `Bar` and `SonOfFoo` maps to `Baz`, then `SonOfFoo` should only inherit `Foo`'s mappings _if_ `Baz` is based on `Bar`.  Otherwise the mappings may be invalid.

Previously, we emitted a warning, but let the (bad) inherited mappings through.

Fixes standardhealth/shr-fhir-export#62