### PR TITLE
Removes value set constraints when applying fixed values constraints

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -577,8 +577,12 @@ class Expander {
       // Remove the previous type constraint since this one supercedes it
       constraints = constraints.filter(cst => cst !== previous);
     }
-    constraints.push(constraint);
 
+    // As a code constraint is a fixed value, we no longer need to retain value set constraints
+    const vsConstraints = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).valueSet.constraints;
+    vsConstraints.forEach(prev => constraints = constraints.filter(cst => cst !== prev))
+    
+    constraints.push(constraint);
     return constraints;
   }
 
@@ -675,6 +679,11 @@ class Expander {
       // Remove the previous type constraint since this one supercedes it
       constraints = constraints.filter(cst => cst !== previous);
     }
+
+    // As a boolean constraint is a fixed value, we no longer need to retain value set constraints
+    const vsConstraints = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).valueSet.constraints;
+    vsConstraints.forEach(prev => constraints = constraints.filter(cst => cst !== prev))
+
     constraints.push(constraint);
 
     return constraints;

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -1667,7 +1667,6 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org/valueset'))
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
         .withInheritance(models.OVERRIDDEN)
     );


### PR DESCRIPTION
(This specifically applies to code and boolean constraints.)

This seems to be effective, but I have two concerns:

1.) This assumes priority of the fixed value constraint over a value set constraint in all cases.
2.) The only case where this wouldn't be true, would be if a based on overwrote a fixed value constraint with a broader value set constraint. As far as I can tell this isn't supported by the tooling, and logically thinking about it, I don't see why we would want them to be able to broaden the constraint anyway.

Let me know if that will be an issue, or if you have any additional feedback