### PR TITLE
CIMCORE / Canonical JSON

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -228,17 +228,17 @@ class Expander {
   }
 
   expandHierarchy(element) {
-    const setOriginalModifier = (value) => {
+    const setCurrentElementAsOriginalModifier = (value) => {
       if (value.options) {
-        value.options.forEach(v => setOriginalModifier(v));
+        value.options.forEach(v => setCurrentElementAsOriginalModifier(v));
       } else {
-        // value.constraints.forEach(c => c.lastModifiedBy = element);
+        value.constraints.forEach(c => c.lastModifiedBy = element.identifier);
       }
     }
 
     if (element.basedOn.length == 0) {
-      if (element.value) setOriginalModifier(element.value);
-      if (element.fields) element.fields.forEach(f => setOriginalModifier(f));
+      if (element.value) setCurrentElementAsOriginalModifier(element.value);
+      if (element.fields) element.fields.forEach(f => setCurrentElementAsOriginalModifier(f));
 
     } else {
       for (const baseID of element.basedOn) {
@@ -260,35 +260,42 @@ class Expander {
             if (parent.inheritedFrom) {
               child.inheritedFrom = parent.inheritedFrom;
             } else {
-              child.inheritedFrom = base
+              child.inheritedFrom = base.identifier;
             };
           }
 
-          // if (child.constraints.length > 0 && child.identifier) {
-          //   for (const c of child.constraints) {
-          //     let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
-          //     if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
-          //       // c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
-          //     } else {
-          //       // c.lastModifiedBy = element;
-          //     };
-          //   }
-          // } 
+          if (child.constraints.length > 0 && child.identifier) {
+            for (const c of child.constraints) {
+              let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
+              if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
+                c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
+              } else {
+                c.lastModifiedBy = element.identifier;
+              };
+            }
+          } 
         }
 
         var manageCardHistory = (parent, child) => {
-          // if (child.effectiveCard.equals(child.card)) return;
-          // if (child && parent.effectiveCard != child.effectiveCard) {
-          //   if (parent.constraintsFilter.own.card._constraints.length > 0) {
-          //     var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card);
-          //     if (parent.card.history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
-          //       parent.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
-          //     }
-          //   } else {
-          //     child.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
-          //   }
-          //   child.card.history.push(...parent.card.history);
-          // }
+          if (child.effectiveCard.equals(child.card)) {
+            return;
+          } else {
+            if (parent.constraintsFilter.own.card.constraints.length > 0) {
+              let oldCard = parent.constraintsFilter.own.card.constraints[0].card.clone();
+              oldCard.source = base.identifier;
+              if (parent.card.history.filter(h => h.source == oldCard.source).length == 0) { //if unique
+                parent.card.withHistory(oldCard);
+              }
+            } else {
+              let oldCard = parent.card.clone();
+              oldCard.source = base.identifier;
+              child.card.withHistory(oldCard)
+            }
+
+            if (parent.card.history) {
+              child.card.withHistories(parent.card.history);
+            }
+          }
         }
 
         if (element.value) {
@@ -296,7 +303,7 @@ class Expander {
             manageValueInheritance(base.value, element.value)
             manageCardHistory(base.value, element.value);
           } else {
-            setOriginalModifier(element.value);
+            setCurrentElementAsOriginalModifier(element.value);
           }
         }
 
@@ -306,7 +313,7 @@ class Expander {
             manageValueInheritance(baseField, ef);
             manageCardHistory(baseField, ef);
           } else {
-            setOriginalModifier(ef);
+            setCurrentElementAsOriginalModifier(ef);
           }
         }
       

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -44,11 +44,6 @@ class Expander {
       }
     }
 
-    // var key = true;
-    // while (key) {
-
-    // }
-
     const entryDE = this._expanded.dataElements.find('shr.base', 'Entry');
     let entryFields = null;
     if (!entryDE) {
@@ -83,11 +78,9 @@ class Expander {
             if (parent.value) {
               if (!(parent.value instanceof models.TBD)) {
                 inheritance = models.OVERRIDDEN;
-                // de.value.inheritedFrom = parent;                
               }
               if (parent.value.equals(de.value, true)) {
                 inheritance = models.INHERITED;
-                // de.value.inheritedFrom = parent;
                 break;
               }
             }
@@ -108,10 +101,8 @@ class Expander {
             });
             if (i >= 0) {
               inheritance = models.OVERRIDDEN;
-              // field.inheritedFrom = parent;              
               if (field.equals(parent.fields[i], true)) {
                 inheritance = models.INHERITED;
-                // field.inheritedFrom = parent;                
                 break;
               }
             }
@@ -142,10 +133,8 @@ class Expander {
               if (!de.fields[i].inheritance) {
                 if (!field.equals(de.fields[i])) {
                   de.fields[i].inheritance = models.OVERRIDDEN;
-                  // de.fields[i].inheritedFrom = parent;                  
                 } else {
                   de.fields[i].inheritance = models.INHERITED;
-                  // de.fields[i].inheritedFrom = parent;
                   
                 }
               }
@@ -227,9 +216,9 @@ class Expander {
       }
 
       const expanded = element.clone();
-      expanded.value = mergedValue;
+      if (mergedValue) expanded.value = mergedValue;
       expanded.fields = mergedFields;
-      this.expandHierarchy(expanded);      
+      this.expandHierarchy(expanded);
       this._expanded.dataElements.add(expanded);
       return expanded;
     } finally {
@@ -239,19 +228,17 @@ class Expander {
   }
 
   expandHierarchy(element) {
-    var addNewValueLastModifiedBy = (value) => {
+    const setOriginalModifier = (value) => {
       if (value.options) {
-        value.options.forEach(v => addNewValueLastModifiedBy(v));
+        value.options.forEach(v => setOriginalModifier(v));
       } else {
-        value.constraints.forEach(c => c.lastModifiedBy = element);
+        // value.constraints.forEach(c => c.lastModifiedBy = element);
       }
     }
 
     if (element.basedOn.length == 0) {
-      if (element.value)
-        addNewValueLastModifiedBy(element.value);
-
-      element.fields.forEach(f => addNewValueLastModifiedBy(f));
+      if (element.value) setOriginalModifier(element.value);
+      if (element.fields) element.fields.forEach(f => setOriginalModifier(f));
 
     } else {
       for (const baseID of element.basedOn) {
@@ -270,35 +257,38 @@ class Expander {
 
         var manageValueInheritance = (parent, child) => {
           if (child.inheritedFrom == null) {
-            if (parent.inheritedFrom) child.inheritedFrom = parent.inheritedFrom;
-            else child.inheritedFrom = base;
+            if (parent.inheritedFrom) {
+              child.inheritedFrom = parent.inheritedFrom;
+            } else {
+              child.inheritedFrom = base
+            };
           }
 
-          if (child.constraints.length > 0 && child.identifier) {
-            for (const c of child.constraints) {
-              let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
-              if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
-                c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
-              } else {
-                c.lastModifiedBy = element;
-              };
-            }
-          } 
+          // if (child.constraints.length > 0 && child.identifier) {
+          //   for (const c of child.constraints) {
+          //     let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
+          //     if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
+          //       // c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
+          //     } else {
+          //       // c.lastModifiedBy = element;
+          //     };
+          //   }
+          // } 
         }
 
         var manageCardHistory = (parent, child) => {
-          if (child.effectiveCard.equals(child.card)) return;
-          if (child && parent.effectiveCard != child.effectiveCard) {
-            if (parent.constraintsFilter.own.card._constraints.length > 0) {
-              var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card);
-              if (parent.card.history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
-                parent.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
-              }
-            } else {
-              child.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
-            }
-            child.card.history.push(...parent.card.history);
-          }
+          // if (child.effectiveCard.equals(child.card)) return;
+          // if (child && parent.effectiveCard != child.effectiveCard) {
+          //   if (parent.constraintsFilter.own.card._constraints.length > 0) {
+          //     var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card);
+          //     if (parent.card.history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
+          //       parent.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
+          //     }
+          //   } else {
+          //     child.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
+          //   }
+          //   child.card.history.push(...parent.card.history);
+          // }
         }
 
         if (element.value) {
@@ -306,24 +296,8 @@ class Expander {
             manageValueInheritance(base.value, element.value)
             manageCardHistory(base.value, element.value);
           } else {
-            addNewValueLastModifiedBy(element.value);
+            setOriginalModifier(element.value);
           }
-          // if (base.value && element.value) {
-          //   var matchTerm = (el) => {
-          //     if (el.identifier) return el.identifier; else
-          //     if (el.constructor.name == "ChoiceValue") return el;
-          //     else return el;
-          //   }
-          //   if (matchTerm(base.value).equals(matchTerm(element.value))) {
-          //     manageValueInheritance(base.value, element.value)
-          //     manageCardHistory(base.value, element.value);
-          //   }
-          // }
-
-          // if (base.value.identifier && element.value.identifier) {
-          // if (base.value.identifier.equals(element.value.identifier)) {
-          // }
-          // }
         }
 
         for (const ef of element.fields) {
@@ -332,7 +306,7 @@ class Expander {
             manageValueInheritance(baseField, ef);
             manageCardHistory(baseField, ef);
           } else {
-            addNewValueLastModifiedBy(ef);
+            setOriginalModifier(ef);
           }
         }
       

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -83,11 +83,11 @@ class Expander {
             if (parent.value) {
               if (!(parent.value instanceof models.TBD)) {
                 inheritance = models.OVERRIDDEN;
-                de.value.inheritedFrom = parent;                
+                // de.value.inheritedFrom = parent;                
               }
               if (parent.value.equals(de.value, true)) {
                 inheritance = models.INHERITED;
-                de.value.inheritedFrom = parent;
+                // de.value.inheritedFrom = parent;
                 break;
               }
             }
@@ -108,10 +108,10 @@ class Expander {
             });
             if (i >= 0) {
               inheritance = models.OVERRIDDEN;
-              field.inheritedFrom = parent;              
+              // field.inheritedFrom = parent;              
               if (field.equals(parent.fields[i], true)) {
                 inheritance = models.INHERITED;
-                field.inheritedFrom = parent;                
+                // field.inheritedFrom = parent;                
                 break;
               }
             }
@@ -142,10 +142,10 @@ class Expander {
               if (!de.fields[i].inheritance) {
                 if (!field.equals(de.fields[i])) {
                   de.fields[i].inheritance = models.OVERRIDDEN;
-                  de.fields[i].inheritedFrom = parent;                  
+                  // de.fields[i].inheritedFrom = parent;                  
                 } else {
                   de.fields[i].inheritance = models.INHERITED;
-                  de.fields[i].inheritedFrom = parent;
+                  // de.fields[i].inheritedFrom = parent;
                   
                 }
               }
@@ -255,25 +255,56 @@ class Expander {
         this.expandHierarchy(base);
       }
 
-      for (const bf of base.fields) {
-        // console.log(element.fields)
-        let currField = element.fields.find((f => (f.identifier != null) && f.identifier.equals(bf.identifier)));
-        if (!currField || currField.effectiveCard.equals(currField.card)) {
-          continue;
-        }
-        if (currField && bf.effectiveCard != currField.effectiveCard) {
-          if (bf.constraintsFilter.own.card._constraints.length > 0) {
-            var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, bf.constraintsFilter.own.card._constraints[0]._card);
-            if (bf.card._history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
-              bf.card._history.push(Object.assign({ "source": base.identifier.fqn }, bf.constraintsFilter.own.card._constraints[0]._card));
-            }  
-          } else {
-            currField.card._history.push(Object.assign({ "source": base.identifier.fqn }, bf.card))
-          }
-          currField.card._history.push(...bf.card._history);
+      var manageValueInheritance = (parent, child) => {
+        if (child.inheritedFrom == null) {
+          if (parent.inheritedFrom) child.inheritedFrom = parent.inheritedFrom;
+          else child.inheritedFrom = base;
         }
       }
-     
+
+      var manageCardHistory = (parent, child) => {
+        if (child.effectiveCard.equals(child.card)) return;
+        if (child && parent.effectiveCard != child.effectiveCard) {
+          if (parent.constraintsFilter.own.card._constraints.length > 0) {
+            var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card);
+            if (parent.card._history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
+              parent.card._history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
+            }  
+          } else {
+            child.card._history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
+          }
+          child.card._history.push(...parent.card._history);
+        }
+      }
+
+      if (base.value && element.value) {
+        // if (base.value && element.value) {
+        //   var matchTerm = (el) => {
+        //     if (el.identifier) return el.identifier; else
+        //     if (el.constructor.name == "ChoiceValue") return el;
+        //     else return el;
+        //   }
+        //   if (matchTerm(base.value).equals(matchTerm(element.value))) {
+        //     manageValueInheritance(base.value, element.value)
+        //     manageCardHistory(base.value, element.value);
+        //   }
+        // }
+
+        // if (base.value.identifier && element.value.identifier) {
+          // if (base.value.identifier.equals(element.value.identifier)) {
+            manageValueInheritance(base.value, element.value)
+            manageCardHistory(base.value, element.value);
+          // }
+        // }
+      }
+
+      for (const bf of base.fields) {
+        // let matchTerm = (el) => el.identifier ? el.identifier.fqn : el.toString()
+        let currField = element.fields.find(f => f.identifier != null && f.identifier.equals(bf.identifier));
+        if (!currField) continue;
+        manageValueInheritance(bf, currField);
+        manageCardHistory(bf, currField);
+      }
       
       element.hierarchy.push(...base.hierarchy);
       element.hierarchy.push(base);

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -258,7 +258,18 @@ class Expander {
       var manageValueInheritance = (parent, child) => {
         if (child.inheritedFrom == null) {
           if (parent.inheritedFrom) child.inheritedFrom = parent.inheritedFrom;
-          else child.inheritedFrom = base;
+          else child.inheritedFrom = base;  
+        }
+
+        if (child.constraints.length > 0 && child.identifier) {
+          for (const c of child.constraints) {
+            let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
+            if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
+              c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
+            } else {
+              c.lastModifiedBy = element;
+            };
+          }
         }
       }
 
@@ -267,13 +278,13 @@ class Expander {
         if (child && parent.effectiveCard != child.effectiveCard) {
           if (parent.constraintsFilter.own.card._constraints.length > 0) {
             var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card);
-            if (parent.card._history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
-              parent.card._history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
+            if (parent.card.history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
+              parent.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
             }  
           } else {
-            child.card._history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
+            child.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
           }
-          child.card._history.push(...parent.card._history);
+          child.card.history.push(...parent.card.history);
         }
       }
 

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -44,10 +44,15 @@ class Expander {
       }
     }
 
+    // var key = true;
+    // while (key) {
+
+    // }
+
     const entryDE = this._expanded.dataElements.find('shr.base', 'Entry');
     let entryFields = null;
     if (!entryDE) {
-      logger.warn('Could not find expanded definition of shr.base.Entry. Inheritance calculations will be incomplete.');
+      logger.warn('Could not find expanded definition of shr.base.Entry. Inheritance calculations will be incomplete. ERROR_CODE:TBD');
       entryFields = {
         'shr.core': { 'Version': true },
         'shr.base': {}
@@ -67,7 +72,7 @@ class Expander {
           }
           const parent = this._expanded.dataElements.findByIdentifier(basedOn);
           if (!parent) {
-            logger.error(`Could not find based on element %s for child element %s.`, basedOn, de.identifier);
+            logger.error(`Could not find based on element %s for child element %s. ERROR_CODE:TBD`, basedOn, de.identifier);
           } else {
             parents.push(parent);
           }
@@ -78,9 +83,11 @@ class Expander {
             if (parent.value) {
               if (!(parent.value instanceof models.TBD)) {
                 inheritance = models.OVERRIDDEN;
+                de.value.inheritedFrom = parent;                
               }
               if (parent.value.equals(de.value, true)) {
                 inheritance = models.INHERITED;
+                de.value.inheritedFrom = parent;
                 break;
               }
             }
@@ -101,8 +108,10 @@ class Expander {
             });
             if (i >= 0) {
               inheritance = models.OVERRIDDEN;
+              field.inheritedFrom = parent;              
               if (field.equals(parent.fields[i], true)) {
                 inheritance = models.INHERITED;
+                field.inheritedFrom = parent;                
                 break;
               }
             }
@@ -133,8 +142,11 @@ class Expander {
               if (!de.fields[i].inheritance) {
                 if (!field.equals(de.fields[i])) {
                   de.fields[i].inheritance = models.OVERRIDDEN;
+                  de.fields[i].inheritedFrom = parent;                  
                 } else {
                   de.fields[i].inheritance = models.INHERITED;
+                  de.fields[i].inheritedFrom = parent;
+                  
                 }
               }
             }
@@ -217,11 +229,54 @@ class Expander {
       const expanded = element.clone();
       expanded.value = mergedValue;
       expanded.fields = mergedFields;
+      this.expandHierarchy(expanded);      
       this._expanded.dataElements.add(expanded);
       return expanded;
     } finally {
       logger.debug('Done expanding element');
       logger = lastLogger;
+    }
+  }
+
+  expandHierarchy(element) {
+    for (const baseID of element.basedOn) {
+      // console.log(baseID)
+      if (baseID instanceof models.TBD) {
+        continue;
+      }
+      const base = this.lookup(baseID);
+      if (typeof base === 'undefined') {
+        logger.error('Reference to non-existing base: %s. ERROR_CODE:12002', baseID.fqn);
+        continue;
+      }
+
+      
+      if (base.hierarchy.length == 0 && base.basedOn.length > 0) {
+        this.expandHierarchy(base);
+      }
+
+      for (const bf of base.fields) {
+        // console.log(element.fields)
+        let currField = element.fields.find((f => (f.identifier != null) && f.identifier.equals(bf.identifier)));
+        if (!currField || currField.effectiveCard.equals(currField.card)) {
+          continue;
+        }
+        if (currField && bf.effectiveCard != currField.effectiveCard) {
+          if (bf.constraintsFilter.own.card._constraints.length > 0) {
+            var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, bf.constraintsFilter.own.card._constraints[0]._card);
+            if (bf.card._history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
+              bf.card._history.push(Object.assign({ "source": base.identifier.fqn }, bf.constraintsFilter.own.card._constraints[0]._card));
+            }  
+          } else {
+            currField.card._history.push(Object.assign({ "source": base.identifier.fqn }, bf.card))
+          }
+          currField.card._history.push(...bf.card._history);
+        }
+      }
+     
+      
+      element.hierarchy.push(...base.hierarchy);
+      element.hierarchy.push(base);
     }
   }
 

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -47,7 +47,7 @@ class Expander {
     const entryDE = this._expanded.dataElements.find('shr.base', 'Entry');
     let entryFields = null;
     if (!entryDE) {
-      logger.warn('Could not find expanded definition of shr.base.Entry. Inheritance calculations will be incomplete. ERROR_CODE:TBD');
+      logger.warn('Could not find expanded definition of shr.base.Entry. Inheritance calculations will be incomplete. ERROR_CODE:12036');
       entryFields = {
         'shr.core': { 'Version': true },
         'shr.base': {}
@@ -67,7 +67,7 @@ class Expander {
           }
           const parent = this._expanded.dataElements.findByIdentifier(basedOn);
           if (!parent) {
-            logger.error(`Could not find based on element %s for child element %s. ERROR_CODE:TBD`, basedOn, de.identifier);
+            logger.error(`Could not find based on element %s for child element %s. ERROR_CODE:12037`, basedOn, de.identifier);
           } else {
             parents.push(parent);
           }
@@ -226,8 +226,27 @@ class Expander {
       logger = lastLogger;
     }
   }
+  
+  /*
+  expandHierarchy - (DataElement)
 
+  This takes a data element and recursively transverses its hierarchy of 'Based On' parent elements, 
+  determining the original source of fields/values (.inheritedFrom), the most recent parent to modify
+  constraints on fields/values (.lastModifiedBy), and the full history of field/value cardinalities.
+
+  The element.hierarchy is a list of its parental hierarchy, and also serves to determine if an element
+  has already undergone expansion. 
+
+  By recursively filling out hierarchy, inheritance, and modifier information, the lower level child
+  elements can inherit the parents historical information.
+  */
   expandHierarchy(element) {
+    /*
+    setCurrentElementAsOriginalModifier - (Value)
+    
+    Sets the current expanding element to be the original modifier for all value constraints. It also 
+    checks for ChoiceValues, and recursively fills out that information for those cases.
+    */
     const setCurrentElementAsOriginalModifier = (value) => {
       if (value.options) {
         value.options.forEach(v => setCurrentElementAsOriginalModifier(v));
@@ -255,7 +274,17 @@ class Expander {
           this.expandHierarchy(base);
         }
 
-        var manageValueInheritance = (parent, child) => {
+        /*
+        setCurrentElementAsOriginalModifier - (Value, Value)
+
+        Determines the original defining source of value (inheritedFrom). If there is no
+        recursively built parent inheritance information, then it must be the current expanding
+        element.
+
+        For each of the child value's constraints, it tries to match it with a parent constraint,
+        and similarly determines the 'lastModifiedBy' information using the result of that match.
+        */
+        const manageValueInheritance = (parent, child) => {
           if (child.inheritedFrom == null) {
             if (parent.inheritedFrom) {
               child.inheritedFrom = parent.inheritedFrom;
@@ -264,36 +293,43 @@ class Expander {
             };
           }
 
-          if (child.constraints.length > 0 && child.identifier) {
+          if (child.constraints.length > 0) {
             for (const c of child.constraints) {
-              let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
+              const matchedParentConstraint = parent.constraints.find(p => p.equals(c));
               if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
                 c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
               } else {
                 c.lastModifiedBy = element.identifier;
-              };
+              }
             }
           } 
         }
 
-        var manageCardHistory = (parent, child) => {
+        /*
+        manageCardHistory - (Value, Value)
+
+        Builds the full history of a value's cardinality by recursively tranversing the
+        value's parents and cardinality constraint information from each parent source.
+        */
+        const manageCardHistory = (parent, child) => {
           if (child.effectiveCard.equals(child.card)) {
             return;
           } else {
-            if (parent.constraintsFilter.own.card.constraints.length > 0) {
-              let oldCard = parent.constraintsFilter.own.card.constraints[0].card.clone();
+            if (parent.constraintsFilter.own.card.hasConstraints) {
+              const oldCard = parent.constraintsFilter.own.card.constraints[0].card.clone();
               oldCard.source = base.identifier;
-              if (parent.card.history.filter(h => h.source == oldCard.source).length == 0) { //if unique
+              if (!parent.card.history.find(h => h.source == oldCard.source)) { //if unique
                 parent.card.withHistory(oldCard);
               }
             } else {
-              let oldCard = parent.card.clone();
+              const oldCard = parent.card.clone();
               oldCard.source = base.identifier;
               child.card.withHistory(oldCard)
             }
 
             if (parent.card.history) {
-              child.card.withHistories(parent.card.history);
+              if (!child.card.history) child.card.history = []
+              child.card.history.unshift(...parent.card.history);
             }
           }
         }
@@ -308,7 +344,7 @@ class Expander {
         }
 
         for (const ef of element.fields) {
-          let baseField = base.fields.find(f => f.identifier != null && f.identifier.equals(ef.identifier));
+          const baseField = base.fields.find(f => f.identifier != null && f.identifier.equals(ef.identifier));
           if (baseField) {
             manageValueInheritance(baseField, ef);
             manageCardHistory(baseField, ef);
@@ -317,8 +353,7 @@ class Expander {
           }
         }
       
-        element.hierarchy.push(...base.hierarchy);
-        element.hierarchy.push(base);
+        element.hierarchy.push(...base.hierarchy, base);
       }
     }  
   }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -239,87 +239,107 @@ class Expander {
   }
 
   expandHierarchy(element) {
-    for (const baseID of element.basedOn) {
-      // console.log(baseID)
-      if (baseID instanceof models.TBD) {
-        continue;
+    var addNewValueLastModifiedBy = (value) => {
+      if (value.options) {
+        value.options.forEach(v => addNewValueLastModifiedBy(v));
+      } else {
+        value.constraints.forEach(c => c.lastModifiedBy = element);
       }
-      const base = this.lookup(baseID);
-      if (typeof base === 'undefined') {
-        logger.error('Reference to non-existing base: %s. ERROR_CODE:12002', baseID.fqn);
-        continue;
-      }
+    }
+
+    if (element.basedOn.length == 0) {
+      if (element.value)
+        addNewValueLastModifiedBy(element.value);
+
+      element.fields.forEach(f => addNewValueLastModifiedBy(f));
+
+    } else {
+      for (const baseID of element.basedOn) {
+        if (baseID instanceof models.TBD) continue;
+
+        const base = this.lookup(baseID);
+        if (typeof base === 'undefined') {
+          logger.error('Reference to non-existing base: %s. ERROR_CODE:12002', baseID.fqn);
+          continue;
+        }
 
       
-      if (base.hierarchy.length == 0 && base.basedOn.length > 0) {
-        this.expandHierarchy(base);
-      }
-
-      var manageValueInheritance = (parent, child) => {
-        if (child.inheritedFrom == null) {
-          if (parent.inheritedFrom) child.inheritedFrom = parent.inheritedFrom;
-          else child.inheritedFrom = base;  
+        if (base.hierarchy.length == 0 && base.basedOn.length > 0) {
+          this.expandHierarchy(base);
         }
 
-        if (child.constraints.length > 0 && child.identifier) {
-          for (const c of child.constraints) {
-            let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
-            if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
-              c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
+        var manageValueInheritance = (parent, child) => {
+          if (child.inheritedFrom == null) {
+            if (parent.inheritedFrom) child.inheritedFrom = parent.inheritedFrom;
+            else child.inheritedFrom = base;
+          }
+
+          if (child.constraints.length > 0 && child.identifier) {
+            for (const c of child.constraints) {
+              let matchedParentConstraint = parent.constraints.filter(p => p.equals(c)).pop();
+              if (matchedParentConstraint && matchedParentConstraint.lastModifiedBy) {
+                c.lastModifiedBy = matchedParentConstraint.lastModifiedBy;
+              } else {
+                c.lastModifiedBy = element;
+              };
+            }
+          } 
+        }
+
+        var manageCardHistory = (parent, child) => {
+          if (child.effectiveCard.equals(child.card)) return;
+          if (child && parent.effectiveCard != child.effectiveCard) {
+            if (parent.constraintsFilter.own.card._constraints.length > 0) {
+              var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card);
+              if (parent.card.history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
+                parent.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
+              }
             } else {
-              c.lastModifiedBy = element;
-            };
+              child.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
+            }
+            child.card.history.push(...parent.card.history);
           }
         }
-      }
 
-      var manageCardHistory = (parent, child) => {
-        if (child.effectiveCard.equals(child.card)) return;
-        if (child && parent.effectiveCard != child.effectiveCard) {
-          if (parent.constraintsFilter.own.card._constraints.length > 0) {
-            var newHistoryObj = Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card);
-            if (parent.card.history.filter(h => h.source == newHistoryObj.source).length == 0) { //if unique
-              parent.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.constraintsFilter.own.card._constraints[0]._card));
-            }  
-          } else {
-            child.card.history.push(Object.assign({ "source": base.identifier.fqn }, parent.card))
-          }
-          child.card.history.push(...parent.card.history);
-        }
-      }
-
-      if (base.value && element.value) {
-        // if (base.value && element.value) {
-        //   var matchTerm = (el) => {
-        //     if (el.identifier) return el.identifier; else
-        //     if (el.constructor.name == "ChoiceValue") return el;
-        //     else return el;
-        //   }
-        //   if (matchTerm(base.value).equals(matchTerm(element.value))) {
-        //     manageValueInheritance(base.value, element.value)
-        //     manageCardHistory(base.value, element.value);
-        //   }
-        // }
-
-        // if (base.value.identifier && element.value.identifier) {
-          // if (base.value.identifier.equals(element.value.identifier)) {
+        if (element.value) {
+          if (base.value) {
             manageValueInheritance(base.value, element.value)
             manageCardHistory(base.value, element.value);
+          } else {
+            addNewValueLastModifiedBy(element.value);
+          }
+          // if (base.value && element.value) {
+          //   var matchTerm = (el) => {
+          //     if (el.identifier) return el.identifier; else
+          //     if (el.constructor.name == "ChoiceValue") return el;
+          //     else return el;
+          //   }
+          //   if (matchTerm(base.value).equals(matchTerm(element.value))) {
+          //     manageValueInheritance(base.value, element.value)
+          //     manageCardHistory(base.value, element.value);
+          //   }
           // }
-        // }
-      }
 
-      for (const bf of base.fields) {
-        // let matchTerm = (el) => el.identifier ? el.identifier.fqn : el.toString()
-        let currField = element.fields.find(f => f.identifier != null && f.identifier.equals(bf.identifier));
-        if (!currField) continue;
-        manageValueInheritance(bf, currField);
-        manageCardHistory(bf, currField);
-      }
+          // if (base.value.identifier && element.value.identifier) {
+          // if (base.value.identifier.equals(element.value.identifier)) {
+          // }
+          // }
+        }
+
+        for (const ef of element.fields) {
+          let baseField = base.fields.find(f => f.identifier != null && f.identifier.equals(ef.identifier));
+          if (baseField) {
+            manageValueInheritance(baseField, ef);
+            manageCardHistory(baseField, ef);
+          } else {
+            addNewValueLastModifiedBy(ef);
+          }
+        }
       
-      element.hierarchy.push(...base.hierarchy);
-      element.hierarchy.push(base);
-    }
+        element.hierarchy.push(...base.hierarchy);
+        element.hierarchy.push(base);
+      }
+    }  
   }
 
   // mergeValue does a best attempt at merging the values, recording errors as it encounters them.  If the values

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.2.7",
+  "version": "5.3.0",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "^5.2.2",
+    "shr-models": "^5.3.0",
     "shr-test-helpers": "^5.1.1"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.2.2"
+    "shr-models": "^5.3.0"
   }
 }

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -80,7 +80,7 @@ describe('#expand()', () => {
     expect(eSubA.concepts).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
-      .withInheritedFrom(a)
+      .withInheritedFrom(a.identifier)
       .withInheritance(models.INHERITED)
   );
     expect(eSubA.fields).to.be.empty;
@@ -107,9 +107,9 @@ describe('#expand()', () => {
     expect(eSubA.concepts).to.eql([new models.Concept('http://foo.org', 'baz')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
-    .withInheritedFrom(a)
-      .withInheritance(models.INHERITED)
-  );
+        .withInheritedFrom(a.identifier)
+        .withInheritance(models.INHERITED)
+    );
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -129,7 +129,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
-    .withInheritedFrom(a)
+    .withInheritedFrom(a.identifier)
       .withInheritance(models.INHERITED)
   );
     expect(eSubA.fields).to.eql([
@@ -153,7 +153,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
         .withInheritance(models.INHERITED)
   );
     expect(eSubA.fields).to.be.empty;
@@ -176,7 +176,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -200,9 +200,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string'))
         .withCard(new models.Cardinality(0, 1)
-          .addHistory(new models.Cardinality(0, 1), a.identifier.fqn))
-        .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0)))
-        .withInheritedFrom(a)
+          .withHistory(new models.Cardinality(0, 1).withSource(a.identifier)))
+        .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0))
+          .withLastModifiedBy(subA.identifier))
+        .withInheritedFrom(a.identifier)
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -230,8 +231,8 @@ describe('#expand()', () => {
     expect(eSubA.value).to.eql(
       new models.ChoiceValue()
         .withCard(new models.Cardinality(0, 1)
-          .addHistory(new models.Cardinality(0, 1), a.identifier.fqn))
-        .withInheritedFrom(a)
+          .withHistory(new models.Cardinality(0, 1).withSource(a.identifier)))
+        .withInheritedFrom(a.identifier)
         .withOption(new models.IdentifiableValue(pid('string')))
         .withOption(new models.IdentifiableValue(pid('code')))
         .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0)))
@@ -259,7 +260,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1)
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a),
+        .withInheritedFrom(a.identifier),
       new models.IdentifiableValue(id('shr.test', 'SubAFieldA')).withMinMax(1, 1)
     ]);
   });
@@ -281,9 +282,12 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
-      new models.IdentifiableValue(pid('string')).withCard(new models.Cardinality(0, 1).addHistory(new models.Cardinality(0, 1), a.identifier.fqn))
-        .withInheritedFrom(a)
-        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1)))
+      new models.IdentifiableValue(pid('string'))
+        .withCard(new models.Cardinality(0, 1)
+          .withHistory(new models.Cardinality(0, 1).withSource(a.identifier)))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1))
+          .withLastModifiedBy(subA.identifier))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -305,10 +309,13 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
-      new models.IdentifiableValue(id('shr.test', 'AFieldA')).withCard(new models.Cardinality(0, 5).addHistory(new models.Cardinality(0, 5), a.identifier.fqn))
-        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 3)))
+      new models.IdentifiableValue(id('shr.test', 'AFieldA'))
+        .withCard(new models.Cardinality(0, 5)
+          .withHistory(new models.Cardinality(0, 5).withSource(a.identifier)))
+        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 3))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -333,9 +340,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 5)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')])
+          .withLastModifiedBy(subA.identifier))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -358,7 +366,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1) // No constraint since it was invalid
-      .withInheritedFrom(a)  
+      .withInheritedFrom(a.identifier)  
       .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -389,7 +397,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'AVal')).withMinMax(0, 1) // No constraint since it was invalid
-      .withInheritedFrom(a)  
+      .withInheritedFrom(a.identifier)  
       .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -420,9 +428,10 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'AVal')).withMinMax(0, 1)
-        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])) // Last valid constraint
+        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])
+          .withLastModifiedBy(id('shr.test', 'A'))) // Last valid constraint
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -446,7 +455,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1) // retain base cardinality
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -506,9 +515,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AField')).withMinMax(0, 1)
-        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])) // Last valid constraint
+        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])
+          .withLastModifiedBy(id('shr.test', 'A'))) // Last valid constraint
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -537,8 +547,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -565,7 +576,8 @@ describe('#expand()', () => {
     expect(eX.identifier).to.eql(id('shr.test', 'X'));
     expect(eX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'), [id('shr.test', 'B')], false))
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'), [id('shr.test', 'B')], false)
+          .withLastModifiedBy(id('shr.test', 'X')))
     );
     expect(eX.fields).to.be.empty;
   });
@@ -593,7 +605,7 @@ describe('#expand()', () => {
     expect(eY.identifier).to.eql(id('shr.test', 'Y'));
     expect(eY.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'B')).withOnValue(true))
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'B')).withOnValue(true).withLastModifiedBy(id('shr.test', 'Y')))
     );
     expect(eY.fields).to.be.empty;
   });
@@ -621,7 +633,7 @@ describe('#expand()', () => {
     expect(eY.identifier).to.eql(id('shr.test', 'Y'));
     expect(eY.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'B')).withOnValue(true))
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'B')).withOnValue(true).withLastModifiedBy(id('shr.test', 'Y')))
     ]);
   });
 
@@ -648,7 +660,7 @@ describe('#expand()', () => {
     expect(eY.identifier).to.eql(id('shr.test', 'Y'));
     expect(eY.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(pid('string')).withOnValue(true))
+        .withConstraint(new models.TypeConstraint(pid('string')).withOnValue(true).withLastModifiedBy(id('shr.test', 'Y')))
     );
     expect(eY.fields).to.be.empty;
   });
@@ -677,9 +689,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB')))
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -705,7 +718,8 @@ describe('#expand()', () => {
     expect(eX.value).to.be.undefined;
     expect(eX.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'), [id('shr.test', 'B')], false))
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'), [id('shr.test', 'B')], false)
+          .withLastModifiedBy(id('shr.test', 'X')))
     ]);
   });
 
@@ -732,9 +746,10 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A'))
-        .withInheritedFrom(x)
+        .withInheritedFrom(x.identifier)
         .withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA'), [], false))
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA'), [], false)
+          .withLastModifiedBy(id('shr.test', 'SubX')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubX.fields).to.be.empty;
@@ -771,7 +786,7 @@ describe('#expand()', () => {
           .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA2'), [], false))
         )
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(x)
+        .withInheritedFrom(x.identifier)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -801,7 +816,7 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withMinMax(0, 1)
         .withInheritance(models.OVERRIDDEN)
     );
@@ -836,9 +851,10 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
+        .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')])
+          .withLastModifiedBy(id('shr.test', 'SubX')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubX.fields).to.be.empty;
@@ -871,9 +887,10 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
+        .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')])
+          .withLastModifiedBy(id('shr.test', 'SubX')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubX.fields).to.be.empty;
@@ -905,9 +922,10 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'), [], false))
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'), [], false)
+          .withLastModifiedBy(id('shr.test', 'SubX')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubX.fields).to.be.empty;
@@ -942,7 +960,7 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C')))
         .withMinMax(0, 1)
@@ -983,7 +1001,7 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C'))
           .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
@@ -1026,7 +1044,7 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C'))
           .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
@@ -1073,7 +1091,7 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-      .withInheritedFrom(x)  
+      .withInheritedFrom(x.identifier)  
       .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
           .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA'), [], false))
         )
@@ -1116,7 +1134,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-      .withInheritedFrom(a)
+      .withInheritedFrom(a.identifier)
       .withInheritance(models.INHERITED)
     ); // No constraint since it was invalid
     expect(eSubA.fields).to.be.empty;
@@ -1151,8 +1169,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))) // Original constraint
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))
+          .withLastModifiedBy(id('shr.test', 'A'))) // Original constraint
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1184,7 +1203,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1) // No constraint since it was invalid
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
 
   });
@@ -1219,9 +1238,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))) // Original constraint
+        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))
+          .withLastModifiedBy(id('shr.test', 'A'))) // Original constraint
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -1252,7 +1272,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'A'))
         .withMinMax(0, 1)
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(x)
+        .withInheritedFrom(x.identifier)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1285,7 +1305,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'A'))
         .withMinMax(0,1)
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(x)
+        .withInheritedFrom(x.identifier)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1321,7 +1341,7 @@ describe('#expand()', () => {
           .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
           .withOption(new models.IdentifiableValue(id('shr.test', 'B')))
           .withInheritance(models.INHERITED)
-          .withInheritedFrom(x)
+          .withInheritedFrom(x.identifier)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1362,7 +1382,7 @@ describe('#expand()', () => {
         .withOption(new models.IdentifiableValue(id('shr.test', 'B')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C')))
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(x)
+        .withInheritedFrom(x.identifier)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1392,7 +1412,8 @@ describe('#expand()', () => {
     expect(eA.fields).to.be.empty;
     expect(eA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1))
+          .withLastModifiedBy(id('shr.test', 'A')))
     );
   });
 
@@ -1419,7 +1440,8 @@ describe('#expand()', () => {
     expect(eA.value).to.be.undefined;
     expect(eA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1))
+          .withLastModifiedBy(id('shr.test', 'A')))
     ]);
   });
 
@@ -1449,8 +1471,9 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1))
+          .withLastModifiedBy(id('shr.test', 'subA')))
         .withInheritance(models.OVERRIDDEN)
     );
   });
@@ -1478,8 +1501,9 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
     );
   });
@@ -1513,9 +1537,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1))
+          .withLastModifiedBy(id('shr.test', 'subA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)        
+        .withInheritedFrom(a.identifier)        
       ]
     );
   });
@@ -1546,8 +1571,9 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1))
+          .withLastModifiedBy(id('shr.test', 'subA')))
         .withInheritance(models.OVERRIDDEN)
     );
   });
@@ -1575,9 +1601,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]
     );
   });
@@ -1603,7 +1630,8 @@ describe('#expand()', () => {
     expect(eA.value).to.be.undefined;
     expect(eA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(1, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(1, 1)))
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(1, 1))
+          .withLastModifiedBy(id('shr.test', 'A')))
     ]);
   });
 
@@ -1663,7 +1691,8 @@ describe('#expand()', () => {
     expect(eA.fields).to.be.empty;
     expect(eA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(1, 1)))
+        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(1, 1))
+          .withLastModifiedBy(id('shr.test', 'A')))
     );
   });
 
@@ -1731,7 +1760,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
+      .withInheritedFrom(a.identifier)  
       .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
     );
   }); */
@@ -1854,8 +1883,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.ValueSetConstraint('http://foo.org'))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.ValueSetConstraint('http://foo.org')
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1883,8 +1913,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.ValueSetConstraint('http://bar.org')
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1912,8 +1943,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.ValueSetConstraint('http://bar.org')
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1942,9 +1974,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+        .withConstraint(new models.ValueSetConstraint('http://bar.org')
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -1968,9 +2001,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org'))
+        .withConstraint(new models.ValueSetConstraint('http://foo.org')
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -1989,7 +2023,8 @@ describe('#expand()', () => {
     expect(eA.identifier).to.eql(id('shr.test', 'A'));
     expect(eA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')]))
+        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')])
+          .withLastModifiedBy(id('shr.test', 'A')))
     ); // Constraint on 'code' path
     expect(eA.fields).to.be.empty;
     const eB = findExpanded('shr.test', 'B');
@@ -2015,7 +2050,8 @@ describe('#expand()', () => {
     expect(eA.value).to.be.undefined;
     expect(eA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')]))
+        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')])
+          .withLastModifiedBy(id('shr.test', 'A')))
     ]); // Constraint on 'code' path
     const eB = findExpanded('shr.test', 'B');
     expect(eB.identifier).to.eql(id('shr.test', 'B'));
@@ -2041,7 +2077,8 @@ describe('#expand()', () => {
     expect(eA.identifier).to.eql(id('shr.test', 'A'));
     expect(eA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'SubB')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')]))
+        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')])
+          .withLastModifiedBy(id('shr.test', 'A')))
     ); // Constraint on 'code' path
     expect(eA.fields).to.be.empty;
     const eB = findExpanded('shr.test', 'B');
@@ -2055,7 +2092,7 @@ describe('#expand()', () => {
     expect(eSubB.value).to.eql(
       new models.IdentifiableValue(pid('code')).withMinMax(0, 1)
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(b)
+        .withInheritedFrom(b.identifier)
   ); // No constraint
     expect(eSubB.fields).to.be.empty;
   });
@@ -2082,8 +2119,9 @@ describe('#expand()', () => {
     expect(eSubA.value).not.to.be.instanceof(models.IncompleteValue);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(1, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')]))
+        .withInheritedFrom(a.identifier)  
+        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')])
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
@@ -2111,8 +2149,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
-    .withInheritedFrom(a)
-      .withInheritance(models.INHERITED)
+        .withInheritedFrom(a.identifier)
+        .withInheritance(models.INHERITED)
   ); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
@@ -2140,8 +2178,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2169,7 +2208,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1)
     .withInheritance(models.INHERITED)
-    .withInheritedFrom(a)]); // No constraint
+    .withInheritedFrom(a.identifier)]); // No constraint
   });
 
   it('should report an error when putting a valueset constraint on a field already constrained to a code', () => {
@@ -2196,9 +2235,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -2223,8 +2263,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2256,8 +2297,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
+      .withInheritedFrom(a.identifier)  
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2280,7 +2322,8 @@ describe('#expand()', () => {
     expect(eX.identifier).to.eql(id('shr.test', 'X'));
     expect(eX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')])
+          .withLastModifiedBy(id('shr.test', 'X')))
     );
     expect(eX.fields).to.be.empty;
   });
@@ -2302,7 +2345,8 @@ describe('#expand()', () => {
     expect(eX.identifier).to.eql(id('shr.test', 'X'));
     expect(eX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'CodeableConcept')]))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'CodeableConcept')])
+        .withLastModifiedBy(id('shr.test', 'X')))
     );
     expect(eX.fields).to.be.empty;
   });
@@ -2329,8 +2373,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2358,8 +2403,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2387,8 +2433,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2418,8 +2465,9 @@ describe('#expand()', () => {
     expect(eSubA.value).not.to.be.instanceof(models.IncompleteValue);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(1, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+      .withInheritedFrom(a.identifier)  
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')])
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
@@ -2445,9 +2493,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -2469,7 +2518,8 @@ describe('#expand()', () => {
     expect(eX.value).to.be.undefined;
     expect(eX.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')])
+          .withLastModifiedBy(id('shr.test', 'X')))
     ]);
   });
 
@@ -2496,9 +2546,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -2525,9 +2576,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -2553,7 +2605,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
         .withInheritance(models.INHERITED)
     ); // No constraint
     expect(eSubA.fields).to.be.empty;
@@ -2581,7 +2633,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1)
     .withInheritance(models.INHERITED)
-    .withInheritedFrom(a)]); // No constraint
+    .withInheritedFrom(a.identifier)]); // No constraint
   });
 
     // Valid Includes Code Constraints
@@ -2605,8 +2657,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2638,9 +2691,11 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.ValueSetConstraint('http://foo.org/valueset'))
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.ValueSetConstraint('http://foo.org/valueset')
+          .withLastModifiedBy(id('shr.test', 'A')))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2663,7 +2718,8 @@ describe('#expand()', () => {
     expect(eX.identifier).to.eql(id('shr.test', 'X'));
     expect(eX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')])
+          .withLastModifiedBy(id('shr.test', 'X')))
     );
     expect(eX.fields).to.be.empty;
   });
@@ -2685,7 +2741,8 @@ describe('#expand()', () => {
     expect(eX.identifier).to.eql(id('shr.test', 'X'));
     expect(eX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'CodeableConcept')]))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'CodeableConcept')])
+          .withLastModifiedBy(id('shr.test', 'X')))
     );
     expect(eX.fields).to.be.empty;
   });
@@ -2712,9 +2769,11 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritedFrom(a.identifier)  
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2742,9 +2801,11 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2772,8 +2833,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2799,9 +2861,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -2823,7 +2886,8 @@ describe('#expand()', () => {
     expect(eX.value).to.be.undefined;
     expect(eX.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')])
+          .withLastModifiedBy(id('shr.test', 'X')))
     ]);
   });
 
@@ -2850,10 +2914,12 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz'))
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -2880,9 +2946,10 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'))
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
     ]);
   });
 
@@ -2908,7 +2975,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
         .withInheritance(models.INHERITED)
     ); // No constraint
     expect(eSubA.fields).to.be.empty;
@@ -2936,7 +3003,7 @@ describe('#expand()', () => {
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1)
     .withInheritance(models.INHERITED)
-    .withInheritedFrom(a)]); // No constraint
+    .withInheritedFrom(a.identifier)]); // No constraint
   });
 
   // Valid Boolean Constraints
@@ -2960,8 +3027,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.BooleanConstraint(true))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.BooleanConstraint(true)
+          .withLastModifiedBy(id('shr.test', 'SubA')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2984,7 +3052,8 @@ describe('#expand()', () => {
     expect(eX.identifier).to.eql(id('shr.test', 'X'));
     expect(eX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A')).withMinMax(0, 1)
-        .withConstraint(new models.BooleanConstraint(true, [pid('boolean')]))
+        .withConstraint(new models.BooleanConstraint(true, [pid('boolean')])
+          .withLastModifiedBy(id('shr.test', 'X')))
     );
     expect(eX.fields).to.be.empty;
   });
@@ -2999,7 +3068,8 @@ describe('#expand()', () => {
       .withBasedOn(id('shr.test', 'A'))
       .withValue(
         new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
-          .withConstraint(new models.BooleanConstraint(false))
+          .withConstraint(new models.BooleanConstraint(false)
+          .withLastModifiedBy(id('shr.test', 'A')))
       );
     add(a, subA);
 
@@ -3011,8 +3081,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
-      .withInheritedFrom(a)  
-      .withConstraint(new models.BooleanConstraint(false))
+        .withInheritedFrom(a.identifier)
+        .withConstraint(new models.BooleanConstraint(false)
+          .withLastModifiedBy(id('shr.test', 'A')))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -3043,9 +3114,10 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
         .withInheritance(models.INHERITED)
-        .withConstraint(new models.BooleanConstraint(true))
+        .withConstraint(new models.BooleanConstraint(true)
+          .withLastModifiedBy(id('shr.test', 'A')))
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -3070,7 +3142,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
-    .withInheritedFrom(a)
+    .withInheritedFrom(a.identifier)
       .withInheritance(models.INHERITED)
   ); // No constraint
     expect(eSubA.fields).to.be.empty;
@@ -3098,7 +3170,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.TBD('Almost ready!').withMinMax(1, 1)
-      .withInheritedFrom(a)
+      .withInheritedFrom(a.identifier)
     );
 
     const eSubA2 = findExpanded('shr.test', 'SubA2');
@@ -3107,7 +3179,7 @@ describe('#expand()', () => {
     expect(eSubA2.value).to.eql(
         new models.TBD('Not ready yet!')
         .withInheritance(models.INHERITED)
-        .withInheritedFrom(a)
+        .withInheritedFrom(a.identifier)
         .withMinMax(1, 1)
     );
   });
@@ -3132,7 +3204,7 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
-      .withInheritedFrom(a)  
+      .withInheritedFrom(a.identifier)  
       .withInheritance(models.INHERITED)
     );
   });

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -78,7 +78,11 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.description).to.be.undefined;
     expect(eSubA.concepts).to.be.empty;
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
+      .withInheritedFrom(a)
+      .withInheritance(models.INHERITED)
+  );
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -101,7 +105,11 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.description).to.equal('It is SubA.');
     expect(eSubA.concepts).to.eql([new models.Concept('http://foo.org', 'baz')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
+    .withInheritedFrom(a)
+      .withInheritance(models.INHERITED)
+  );
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -119,7 +127,11 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
+    .withInheritedFrom(a)
+      .withInheritance(models.INHERITED)
+  );
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'SubAFieldA')).withMinMax(1, 1)
     ]);
@@ -139,7 +151,11 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
+        .withInheritedFrom(a)
+        .withInheritance(models.INHERITED)
+  );
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -158,7 +174,11 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.be.eql(new models.IdentifiableValue(pid('string')).withMinMax(1, 1).withInheritance(models.INHERITED));
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
+        .withInheritedFrom(a)
+        .withInheritance(models.INHERITED)
+    );
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -178,10 +198,13 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).not.to.be.instanceof(models.IncompleteValue);
     expect(eSubA.value).to.eql(
-      new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
+      new models.IdentifiableValue(pid('string'))
+        .withCard(new models.Cardinality(0, 1)
+          .addHistory(new models.Cardinality(0, 1), a.identifier.fqn))
         .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0)))
+        .withInheritedFrom(a)
         .withInheritance(models.OVERRIDDEN)
-      );
+    );
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -205,12 +228,15 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).not.to.be.instanceof(models.IncompleteValue);
     expect(eSubA.value).to.eql(
-      new models.ChoiceValue().withMinMax(0, 1)
-          .withOption(new models.IdentifiableValue(pid('string')))
-          .withOption(new models.IdentifiableValue(pid('code')))
+      new models.ChoiceValue()
+        .withCard(new models.Cardinality(0, 1)
+          .addHistory(new models.Cardinality(0, 1), a.identifier.fqn))
+        .withInheritedFrom(a)
+        .withOption(new models.IdentifiableValue(pid('string')))
+        .withOption(new models.IdentifiableValue(pid('code')))
         .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0)))
         .withInheritance(models.OVERRIDDEN)
-      );
+    );
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -231,7 +257,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
-      new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1).withInheritance(models.INHERITED),
+      new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1)
+        .withInheritance(models.INHERITED)
+        .withInheritedFrom(a),
       new models.IdentifiableValue(id('shr.test', 'SubAFieldA')).withMinMax(1, 1)
     ]);
   });
@@ -253,7 +281,8 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
-      new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
+      new models.IdentifiableValue(pid('string')).withCard(new models.Cardinality(0, 1).addHistory(new models.Cardinality(0, 1), a.identifier.fqn))
+        .withInheritedFrom(a)
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1)))
         .withInheritance(models.OVERRIDDEN)
     );
@@ -276,9 +305,10 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
     expect(eSubA.fields).to.eql([
-      new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 5)
+      new models.IdentifiableValue(id('shr.test', 'AFieldA')).withCard(new models.Cardinality(0, 5).addHistory(new models.Cardinality(0, 5), a.identifier.fqn))
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 3)))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -305,8 +335,10 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 5)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
+
   // Invalid Cardinality Constraints
 
   it('should report an error when widening cardinality of a value', () => {
@@ -326,7 +358,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(0, 1) // No constraint since it was invalid
-        .withInheritance(models.INHERITED)
+      .withInheritedFrom(a)  
+      .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -356,7 +389,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'AVal')).withMinMax(0, 1) // No constraint since it was invalid
-        .withInheritance(models.INHERITED)
+      .withInheritedFrom(a)  
+      .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -366,14 +400,14 @@ describe('#expand()', () => {
       .withValue(new models.IdentifiableValue(pid('decimal')).withMinMax(1));
     let a = new models.DataElement(id('shr.test', 'A'), true)
       .withValue(
-        new models.IdentifiableValue(aVal.identifier).withMinMax(0, 1)
-          .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')]))
+      new models.IdentifiableValue(aVal.identifier).withMinMax(0, 1)
+        .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')]))
       );
     let subA = new models.DataElement(id('shr.test', 'SubA'), true)
       .withBasedOn(id('shr.test', 'A'))
       .withValue(
-        new models.IdentifiableValue(aVal.identifier).withMinMax(0, 1)
-          .withConstraint(new models.CardConstraint(new models.Cardinality(1), [pid('decimal')]))
+      new models.IdentifiableValue(aVal.identifier).withMinMax(0, 1)
+        .withConstraint(new models.CardConstraint(new models.Cardinality(1), [pid('decimal')]))
       );
     add(a, subA);
 
@@ -388,6 +422,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'AVal')).withMinMax(0, 1)
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])) // Last valid constraint
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -411,6 +446,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1, 1) // retain base cardinality
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -472,6 +508,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'AField')).withMinMax(0, 1)
         .withConstraint(new models.CardConstraint(new models.Cardinality(1, 1), [pid('decimal')])) // Last valid constraint
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -500,7 +537,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -641,6 +679,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB')))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -693,6 +732,7 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'A'))
+        .withInheritedFrom(x)
         .withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA'), [], false))
         .withInheritance(models.OVERRIDDEN)
@@ -700,7 +740,7 @@ describe('#expand()', () => {
     expect(eSubX.fields).to.be.empty;
   });
 
-  it('should allow a sub-type\'s value to be a choice of sub-types of the parent\'s value', function() {
+  it('should allow a sub-type\'s value to be a choice of sub-types of the parent\'s value', function () {
     let a = new models.DataElement(id('shr.test', 'A'), true);
     let subA = new models.DataElement(id('shr.test', 'SubA'), true).withBasedOn(id('shr.test', 'A'));
     let subA2 = new models.DataElement(id('shr.test', 'SubA2'), true).withBasedOn(id('shr.test', 'A'));
@@ -724,13 +764,14 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue().withMinMax(0, 1)
-          .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
-            .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA'), [], false))
-          )
-          .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
-            .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA2'), [], false))
-          )
-          .withInheritance(models.OVERRIDDEN)
+        .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
+          .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA'), [], false))
+        )
+        .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
+          .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA2'), [], false))
+        )
+        .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(x)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -760,7 +801,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-        .withMinMax(0, 1)
+      .withInheritedFrom(x)  
+      .withMinMax(0, 1)
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubX.fields).to.be.empty;
@@ -794,7 +836,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-        .withMinMax(0, 1)
+      .withInheritedFrom(x)  
+      .withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
         .withInheritance(models.OVERRIDDEN)
     );
@@ -828,7 +871,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-        .withMinMax(0, 1)
+      .withInheritedFrom(x)  
+      .withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
         .withInheritance(models.OVERRIDDEN)
     );
@@ -861,7 +905,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B'))
-        .withMinMax(0, 1)
+      .withInheritedFrom(x)  
+      .withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'), [], false))
         .withInheritance(models.OVERRIDDEN)
     );
@@ -897,7 +942,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-        .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
+      .withInheritedFrom(x)  
+      .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C')))
         .withMinMax(0, 1)
         .withInheritance(models.OVERRIDDEN)
@@ -937,7 +983,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-        .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
+      .withInheritedFrom(x)  
+      .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C'))
           .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
         )
@@ -979,7 +1026,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-        .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
+      .withInheritedFrom(x)  
+      .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C'))
           .withConstraint(new models.ValueSetConstraint('http://foo.org', [id('shr.core', 'CodeableConcept')]))
         )
@@ -1025,7 +1073,8 @@ describe('#expand()', () => {
     expect(eSubX.basedOn[0]).to.eql(id('shr.test', 'X'));
     expect(eSubX.value).to.eql(
       new models.ChoiceValue()
-        .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
+      .withInheritedFrom(x)  
+      .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
           .withConstraint(new models.TypeConstraint(id('shr.test', 'SubA'), [], false))
         )
         .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
@@ -1066,7 +1115,10 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
-      new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint since it was invalid
+      new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
+      .withInheritedFrom(a)
+      .withInheritance(models.INHERITED)
+    ); // No constraint since it was invalid
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -1099,7 +1151,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-        .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))) // Original constraint
+      .withInheritedFrom(a)  
+      .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))) // Original constraint
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1131,6 +1184,7 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1) // No constraint since it was invalid
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     ]);
 
   });
@@ -1167,6 +1221,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
         .withConstraint(new models.TypeConstraint(id('shr.test', 'SubB'))) // Original constraint
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -1197,6 +1252,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'A'))
         .withMinMax(0, 1)
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(x)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1229,6 +1285,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.test', 'A'))
         .withMinMax(0,1)
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(x)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1264,6 +1321,7 @@ describe('#expand()', () => {
           .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
           .withOption(new models.IdentifiableValue(id('shr.test', 'B')))
           .withInheritance(models.INHERITED)
+          .withInheritedFrom(x)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1304,6 +1362,7 @@ describe('#expand()', () => {
         .withOption(new models.IdentifiableValue(id('shr.test', 'B')))
         .withOption(new models.IdentifiableValue(id('shr.test', 'C')))
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(x)
     );
     expect(eSubX.fields).to.be.empty;
   });
@@ -1390,7 +1449,8 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
         .withInheritance(models.OVERRIDDEN)
     );
   });
@@ -1418,7 +1478,8 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
         .withInheritance(models.INHERITED)
     );
   });
@@ -1442,9 +1503,6 @@ describe('#expand()', () => {
             new models.IncludesTypeConstraint(id('shr.test','subB'), new models.Cardinality(0,1)))
       );
 
-
-
-
     add(subB, b, a, subA);
 
     doExpand();
@@ -1456,7 +1514,9 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
         .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
-        .withInheritance(models.OVERRIDDEN)]
+        .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)        
+      ]
     );
   });
 
@@ -1486,7 +1546,8 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
         .withInheritance(models.OVERRIDDEN)
     );
   });
@@ -1515,7 +1576,9 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.eql([
       new models.IdentifiableValue((id('shr.test', 'B'))).withMinMax(0, 1)
         .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
-        .withInheritance(models.INHERITED)]
+        .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
+    ]
     );
   });
 
@@ -1579,8 +1642,6 @@ describe('#expand()', () => {
 
   // });
 
-  //it('should allow fields with a very deep path to includes types with properly fitting cardinality', () => {});
-
   it('should allow values to include types with properly fitting cardinality', () => {
     let b = new models.DataElement(id('shr.test', 'B'), true)  //e.g. Observation
       .withValue(new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1));
@@ -1605,10 +1666,6 @@ describe('#expand()', () => {
         .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(1, 1)))
     );
   });
-
-  //it('should allow values with a 2 deep path to includes types with properly fitting cardinality', () => {});
-
-  //it('should allow values with a very deep path to includes types with properly fitting cardinality', () => {});
 
   // Invalid Includes Type Constraints
 
@@ -1674,7 +1731,8 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(0, 1)
-        .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesTypeConstraint(id('shr.test', 'subB'), new models.Cardinality(0, 1)))
     );
   }); */
 
@@ -1796,7 +1854,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org'))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.ValueSetConstraint('http://foo.org'))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1824,7 +1883,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.ValueSetConstraint('http://bar.org'))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1852,7 +1912,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0, 1)
-        .withConstraint(new models.ValueSetConstraint('http://bar.org'))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.ValueSetConstraint('http://bar.org'))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -1883,6 +1944,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://bar.org'))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -1908,6 +1970,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.ValueSetConstraint('http://foo.org'))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -1931,7 +1994,8 @@ describe('#expand()', () => {
     expect(eA.fields).to.be.empty;
     const eB = findExpanded('shr.test', 'B');
     expect(eB.identifier).to.eql(id('shr.test', 'B'));
-    expect(eB.value).to.eql(new models.IdentifiableValue(pid('code')).withMinMax(0, 1)); // No constraint
+    expect(eB.value).to.eql(
+      new models.IdentifiableValue(pid('code')).withMinMax(0, 1)); // No constraint
     expect(eB.fields).to.be.empty;
   });
 
@@ -1955,7 +2019,8 @@ describe('#expand()', () => {
     ]); // Constraint on 'code' path
     const eB = findExpanded('shr.test', 'B');
     expect(eB.identifier).to.eql(id('shr.test', 'B'));
-    expect(eB.value).to.eql(new models.IdentifiableValue(pid('code')).withMinMax(0, 1)); // No constraint
+    expect(eB.value).to.eql(
+      new models.IdentifiableValue(pid('code')).withMinMax(0, 1)); // No constraint
     expect(eB.fields).to.be.empty;
   });
 
@@ -1981,12 +2046,17 @@ describe('#expand()', () => {
     expect(eA.fields).to.be.empty;
     const eB = findExpanded('shr.test', 'B');
     expect(eB.identifier).to.eql(id('shr.test', 'B'));
-    expect(eB.value).to.eql(new models.IdentifiableValue(pid('code')).withMinMax(0, 1)); // No constraint
+    expect(eB.value).to.eql(
+      new models.IdentifiableValue(pid('code')).withMinMax(0, 1)); // No constraint
     expect(eB.fields).to.be.empty;
     const eSubB = findExpanded('shr.test', 'SubB');
     expect(eSubB.identifier).to.eql(id('shr.test', 'SubB'));
     expect(eSubB.basedOn).to.eql([id('shr.test', 'B')]);
-    expect(eSubB.value).to.eql(new models.IdentifiableValue(pid('code')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
+    expect(eSubB.value).to.eql(
+      new models.IdentifiableValue(pid('code')).withMinMax(0, 1)
+        .withInheritance(models.INHERITED)
+        .withInheritedFrom(b)
+  ); // No constraint
     expect(eSubB.fields).to.be.empty;
   });
 
@@ -2012,7 +2082,8 @@ describe('#expand()', () => {
     expect(eSubA.value).not.to.be.instanceof(models.IncompleteValue);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(1, 1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')]))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.ValueSetConstraint('http://foo.org', [pid('code')]))
         .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
@@ -2038,7 +2109,11 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
+    .withInheritedFrom(a)
+      .withInheritance(models.INHERITED)
+  ); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -2065,7 +2140,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2091,7 +2167,9 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
-    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1).withInheritance(models.INHERITED)]); // No constraint
+    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1)
+    .withInheritance(models.INHERITED)
+    .withInheritedFrom(a)]); // No constraint
   });
 
   it('should report an error when putting a valueset constraint on a field already constrained to a code', () => {
@@ -2120,6 +2198,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -2144,7 +2223,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2176,7 +2256,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2248,7 +2329,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2276,7 +2358,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2304,7 +2387,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2334,7 +2418,8 @@ describe('#expand()', () => {
     expect(eSubA.value).not.to.be.instanceof(models.IncompleteValue);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.test', 'B')).withMinMax(1, 1)
-        .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar'), [id('shr.core', 'Coding')]))
         .withInheritance(models.OVERRIDDEN)
       );
     expect(eSubA.fields).to.be.empty;
@@ -2362,6 +2447,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -2412,6 +2498,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -2440,6 +2527,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(0, 1)
         .withConstraint(new models.CodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -2463,7 +2551,11 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
+        .withInheritedFrom(a)
+        .withInheritance(models.INHERITED)
+    ); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -2487,7 +2579,9 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
-    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1).withInheritance(models.INHERITED)]); // No constraint
+    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(0, 1)
+    .withInheritance(models.INHERITED)
+    .withInheritedFrom(a)]); // No constraint
   });
 
     // Valid Includes Code Constraints
@@ -2511,7 +2605,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2543,7 +2638,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.ValueSetConstraint('http://foo.org/valueset'))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.ValueSetConstraint('http://foo.org/valueset'))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar')))
         .withInheritance(models.OVERRIDDEN)
     );
@@ -2616,7 +2712,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
         .withInheritance(models.OVERRIDDEN)
     );
@@ -2645,7 +2742,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'CodeableConcept')).withMinMax(1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
         .withInheritance(models.OVERRIDDEN)
     );
@@ -2674,7 +2772,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
-        .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2702,6 +2801,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -2753,6 +2853,7 @@ describe('#expand()', () => {
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'baz', 'FooBaz')))
         .withInheritance(models.OVERRIDDEN)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -2781,6 +2882,7 @@ describe('#expand()', () => {
       new models.IdentifiableValue(id('shr.core', 'Coding')).withMinMax(1)
         .withConstraint(new models.IncludesCodeConstraint(new models.Concept('http://foo.org/codes', 'bar', 'FooBar')))
         .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
     ]);
   });
 
@@ -2804,7 +2906,11 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(1).withInheritance(models.INHERITED)); // No constraint
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(1)
+        .withInheritedFrom(a)
+        .withInheritance(models.INHERITED)
+    ); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -2828,7 +2934,9 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.be.undefined;
-    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1).withInheritance(models.INHERITED)]); // No constraint
+    expect(eSubA.fields).to.eql([new models.IdentifiableValue(id('shr.test', 'AFieldA')).withMinMax(1)
+    .withInheritance(models.INHERITED)
+    .withInheritedFrom(a)]); // No constraint
   });
 
   // Valid Boolean Constraints
@@ -2852,7 +2960,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
-        .withConstraint(new models.BooleanConstraint(true))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.BooleanConstraint(true))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2902,7 +3011,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
-        .withConstraint(new models.BooleanConstraint(false))
+      .withInheritedFrom(a)  
+      .withConstraint(new models.BooleanConstraint(false))
         .withInheritance(models.INHERITED)
     );
     expect(eSubA.fields).to.be.empty;
@@ -2933,8 +3043,9 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('boolean')).withMinMax(0, 1)
-        .withConstraint(new models.BooleanConstraint(true))
+        .withInheritedFrom(a)
         .withInheritance(models.INHERITED)
+        .withConstraint(new models.BooleanConstraint(true))
     );
     expect(eSubA.fields).to.be.empty;
   });
@@ -2957,7 +3068,11 @@ describe('#expand()', () => {
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
-    expect(eSubA.value).to.eql(new models.IdentifiableValue(pid('string')).withMinMax(0, 1).withInheritance(models.INHERITED)); // No constraint
+    expect(eSubA.value).to.eql(
+      new models.IdentifiableValue(pid('string')).withMinMax(0, 1)
+    .withInheritedFrom(a)
+      .withInheritance(models.INHERITED)
+  ); // No constraint
     expect(eSubA.fields).to.be.empty;
   });
 
@@ -2982,7 +3097,8 @@ describe('#expand()', () => {
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
-        new models.TBD('Almost ready!').withMinMax(1, 1)
+      new models.TBD('Almost ready!').withMinMax(1, 1)
+      .withInheritedFrom(a)
     );
 
     const eSubA2 = findExpanded('shr.test', 'SubA2');
@@ -2990,7 +3106,9 @@ describe('#expand()', () => {
     expect(eSubA2.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA2.value).to.eql(
         new models.TBD('Not ready yet!')
-            .withInheritance(models.INHERITED).withMinMax(1, 1)
+        .withInheritance(models.INHERITED)
+        .withInheritedFrom(a)
+        .withMinMax(1, 1)
     );
   });
 
@@ -3014,7 +3132,8 @@ describe('#expand()', () => {
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
     expect(eSubA.value).to.eql(
       new models.IdentifiableValue(pid('string')).withMinMax(1, 1)
-        .withInheritance(models.INHERITED)
+      .withInheritedFrom(a)  
+      .withInheritance(models.INHERITED)
     );
   });
 });

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -235,7 +235,8 @@ describe('#expand()', () => {
         .withInheritedFrom(a.identifier)
         .withOption(new models.IdentifiableValue(pid('string')))
         .withOption(new models.IdentifiableValue(pid('code')))
-        .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0)))
+        .withConstraint(new models.CardConstraint(new models.Cardinality(0, 0))
+           .withLastModifiedBy(subA.identifier))
         .withInheritance(models.OVERRIDDEN)
     );
     expect(eSubA.fields).to.be.empty;

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,9 +881,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"
+shr-models@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.3.0.tgz#e2416ca103e5ad9a434d85c20b40a7a516ce70e7"
 
 shr-test-helpers@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This adds better hierarchical information, modification information, and constraint history.

The `expandHierarchy` function recursively traverses each Element's `basedOn`, building off of each parent's hierarchical and inheritance information to form a more complete child element.

The `manageValueInheritance` matches child properties with parent properties to determine the original source of inheritance (either the parent itself, or the parent has pre-expanded inheritance information the child can use).

The `manageCardHistory` compiles a history of cardinality changes in a similar fashion and appends that to the child's cardinality.