### PR TITLE
Updates expander to use v5.2.2, fixes unit test conflicts

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -283,7 +283,7 @@ class Expander {
       for (let i=0; i < mergedValue.options.length; i++) {
         mergedValue.options[i] = this.findMatchingOption(element, oldChoiceValue, mergedValue.options[i], false);
       }
-      if (!mergedValue.effectiveCard) {
+      if (!mergedValue.card || !mergedValue.effectiveCard) {
         mergedValue.card = oldChoiceValue.effectiveCard;
       }
     } else if (newValue instanceof models.TBD) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "^5.2.1",
+    "shr-models": "^5.2.2",
     "shr-test-helpers": "^5.1.1"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.2.1"
+    "shr-models": "^5.2.2"
   }
 }

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -1061,7 +1061,7 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('type').and.to.contain('shr.test.B').and.to.contain('shr.test.NotSubB');
+    expect(err.errors()[0].msg).to.contain('type').and.to.contain('B').and.to.contain('shr.test.NotSubB');
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
@@ -1123,7 +1123,7 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('type').and.to.contain('shr.test.B').and.to.contain('shr.test.NotSubB');
+    expect(err.errors()[0].msg).to.contain('type').and.to.contain('B').and.to.contain('shr.test.NotSubB');
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
@@ -1158,7 +1158,7 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('type').and.to.contain('shr.test.SubB').and.to.contain('shr.test.SubB2');
+    expect(err.errors()[0].msg).to.contain('type').and.to.contain('SubB').and.to.contain('shr.test.SubB2');
     const eSubA = findExpanded('shr.test', 'SubA');
     expect(eSubA.identifier).to.eql(id('shr.test', 'SubA'));
     expect(eSubA.basedOn).to.eql([id('shr.test', 'A')]);
@@ -1187,7 +1187,7 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('12007').and.to.contain('shr.test.NotSubA');
+    expect(err.errors()[0].msg).to.contain('12007').and.to.contain('NotSubA');
     const eSubX = findExpanded('shr.test', 'SubX');
     expect(eSubX.identifier).to.eql(id('shr.test', 'SubX'));
     expect(eSubX.basedOn).to.have.length(1);
@@ -1219,7 +1219,7 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('12036').and.to.contain('shr.test.NotSubA');
+    expect(err.errors()[0].msg).to.contain('12036').and.to.contain('NotSubA');
     const eSubX = findExpanded('shr.test', 'SubX');
     expect(eSubX.identifier).to.eql(id('shr.test', 'SubX'));
     expect(eSubX.basedOn).to.have.length(1);
@@ -1253,7 +1253,7 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('12006').and.to.contain('shr.test.C');
+    expect(err.errors()[0].msg).to.contain('12006').and.to.contain('C');
     const eSubX = findExpanded('shr.test', 'SubX');
     expect(eSubX.identifier).to.eql(id('shr.test', 'SubX'));
     expect(eSubX.basedOn).to.have.length(1);
@@ -1292,7 +1292,7 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('12036').and.to.contain('shr.test.D');
+    expect(err.errors()[0].msg).to.contain('12036').and.to.contain('D');
     const eSubX = findExpanded('shr.test', 'SubX');
     expect(eSubX.identifier).to.eql(id('shr.test', 'SubX'));
     expect(eSubX.basedOn).to.have.length(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,9 +881,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.1.tgz#23108d369a0be9fa2518d9be4c1e53685d9dd776"
+shr-models@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"
 
 shr-test-helpers@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
There were two types of unit tests breaking:

1. Value Cardinality is null, therefore `.effectiveCard()` crashes (due to the `this.card.clone()` function call in effectiveCard), e.g
```
  1) #expand() should allow a sub-type's value to be a choice of sub-types of the parent's value:
     TypeError: Cannot read property 'clone' of undefined
      at ChoiceValue.get effectiveCard [as effectiveCard] (/Users/abhatnagar/Code/SHR/shr-models/lib/models.js:933:26)
```

2. Element label changes result in different error messages, e.g.
```
  6) #expand() should report an error when new value type isn't based on constrained type:
     AssertionError: expected 'Cannot constrain type of B to shr.test.NotSubB. ERROR_CODE:12014' to include 'shr.test.B'
```

The full list of fixed unit tests is the following:
```
    1) should allow a sub-type's value to be a choice of sub-types of the parent's value
    2) should allow sub-type value to narrow a choice to a choice subset
    3) should allow sub-type value to narrow a choice to a choice subset and retain original value set constraint
    4) should allow sub-type value to narrow a choice to a choice subset and retain new value set constraint
    5) should allow sub-type value to narrow a choice to a choice subset with sub-types of original choice
    6) should report an error when new value type isn't based on constrained type
    7) should report an error when new field type isn't based on constrained type
    8) should report an error when a sub-type's value is not a sub-type of parent's value
    9) should report an error when a sub-type choice contains options that are not sub-types of the parent's value
    10) should report an error when a sub-type value tries to narrow a choice to an element not in the choice
    11) should report an error when a sub-type value tries to narrow a choice to a subset with an element not in the choice
```