### PR TITLE
Expand data elements by file and with file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The expander previously did not add the file name of a data element when adding a data element. This PR addresses that concern.

The only things that need to verified are that the code looks good and doesn't have unexpected results, and that it runs without error when used with the rest of the toolchain. @AmartC already verified that this fix works for his use case, with the CIMPL 6 exporter.