### PR TITLE
Int/Decimal fixed constraints

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1190,7 +1190,8 @@ class Expander {
 
   supportsFixedValueConstraint(identifier, constraint) {
     if (identifier && constraint && 
-      (identifier.name === constraint.type || constraintConversions[constraint.type].includes(identifier.name))) {
+      (identifier.name === constraint.type || 
+      (constraintConversions[constraint.type] && constraintConversions[constraint.type].includes(identifier.name)))) {
       // reset constraint.type in case they are not equal, but identifier.name is allowed conversion
       constraint.type = identifier.name;
       return true;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1048,7 +1048,7 @@ class Expander {
         }
       }
       if (!this.supportsFixedValueConstraint(valID, constraint)) {
-        logger.error('Cannot constrain string value of %s since neither it nor its value is a string. ERROR_CODE:12041', targetLabel);
+        logger.error('Cannot constrain value of %s to %s since neither it nor its value is a %s. ERROR_CODE:12041', targetLabel, constraint.type, constraint.type);
         return previousConstraints;
       }
       // Constraint is on the target's value.  Convert constraint to reference the value explicitly.
@@ -1062,7 +1062,7 @@ class Expander {
     const filtered = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).fixedValue.constraints;
     for (const previous of filtered) {
       if (previous.value != constraint.value) {
-        logger.error('Cannot constrain string value of %s to %s since a previous constraint constrains it to %s. ERROR_CODE:12042', targetLabel, constraint.value, previous.value);
+        logger.error('Cannot constrain %s value of %s to %s since a previous constraint constrains it to %s. ERROR_CODE:12042', constraint.type, targetLabel, constraint.value, previous.value);
         return previousConstraints;
       }
       // Remove the previous type constraint since this one supercedes it

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1038,16 +1038,16 @@ class Expander {
     let targetLabel = this.constraintTargetLabel(value, constraint.path);
 
     // Determine if the constraint is on the specific target or its value
-    if (!this.supportsFixedValueConstraint(target.identifier)) {
+    if (!this.supportsFixedValueConstraint(target.identifier, constraint)) {
       // Isn't directly a fixed value, so try its value
       let valID = this.constraintTargetValueIdentifier(value, constraint.path);
       if(!valID && value instanceof models.ChoiceValue) {
-        let valOption = value.options.find(v => this.supportsFixedValueConstraint(v.identifier));
+        let valOption = value.options.find(v => this.supportsFixedValueConstraint(v.identifier, constraint));
         if(valOption) {
           valID = valOption.identifier;
         }
       }
-      if (!this.supportsFixedValueConstraint(valID)) {
+      if (!this.supportsFixedValueConstraint(valID, constraint)) {
         logger.error('Cannot constrain string value of %s since neither it nor its value is a string. ERROR_CODE:12041', targetLabel);
         return previousConstraints;
       }
@@ -1182,8 +1182,8 @@ class Expander {
     return BOOLEAN.equals(identifier);
   }
 
-  supportsFixedValueConstraint(identifier) {
-    return STRING.equals(identifier);
+  supportsFixedValueConstraint(identifier, constraint) {
+    return identifier && constraint && identifier.name === constraint.type;
   }
 
   checkHasBaseType(identifier, baseIdentifier) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -15,10 +15,12 @@ function expand(specifications, ...exporters) {
 
 const CONCEPT = new models.PrimitiveIdentifier('concept');
 const BOOLEAN = new models.PrimitiveIdentifier('boolean');
+
+// Used to set which types of constraints can be converted.
+// For example, string constraint can be used on value of type uri.
 const constraintConversions = {
-  'integer': ['integer', 'decimal'],
-  'decimal': ['decimal'],
-  'string': ['string', 'uri']
+  'integer': ['decimal'],
+  'string': ['uri']
 }
 
 class Expander {
@@ -1187,7 +1189,9 @@ class Expander {
   }
 
   supportsFixedValueConstraint(identifier, constraint) {
-    if (identifier && constraint && constraintConversions[constraint.type].includes(identifier.name)) {
+    if (identifier && constraint && 
+      (identifier.name === constraint.type || constraintConversions[constraint.type].includes(identifier.name))) {
+      // reset constraint.type in case they are not equal, but identifier.name is allowed conversion
       constraint.type = identifier.name;
       return true;
     }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -15,7 +15,11 @@ function expand(specifications, ...exporters) {
 
 const CONCEPT = new models.PrimitiveIdentifier('concept');
 const BOOLEAN = new models.PrimitiveIdentifier('boolean');
-const STRING = new models.PrimitiveIdentifier('string');
+const constraintConversions = {
+  'integer': ['integer', 'decimal'],
+  'decimal': ['decimal'],
+  'string': ['string', 'uri']
+}
 
 class Expander {
   constructor(specs, ...exporters) {
@@ -1183,7 +1187,11 @@ class Expander {
   }
 
   supportsFixedValueConstraint(identifier, constraint) {
-    return identifier && constraint && identifier.name === constraint.type;
+    if (identifier && constraint && constraintConversions[constraint.type].includes(identifier.name)) {
+      constraint.type = identifier.name;
+      return true;
+    }
+    return false;
   }
 
   checkHasBaseType(identifier, baseIdentifier) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "^6.2.0",
+    "shr-models": "^6.3.0",
     "shr-test-helpers": "^6.0.0"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^6.2.0"
+    "shr-models": "^6.3.0"
   }
 }

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -3397,6 +3397,46 @@ describe('#expand()', () => {
     expect(eSubA.fields).to.be.empty;
   });
 
+  // Valid Fixed URI Constraints
+
+  it('should allow a fixed string constraint to apply to URI values', () => {
+    let a = new models.DataElement(id('shr.test', 'A'), true)
+      .withValue(new models.IdentifiableValue(pid('uri')).withMinMax(0, 1)
+      .withConstraint(new models.FixedValueConstraint('http://example.com/ex.html', 'string')));
+    
+    add(a);
+    doExpand();
+
+    expect(err.hasErrors()).to.be.false;
+    const A = findExpanded('shr.test', 'A');
+    expect(A.identifier).to.eql(id('shr.test', 'A'));
+    expect(A.value).to.eql(
+      new models.IdentifiableValue(pid('uri')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('http://example.com/ex.html', 'uri')
+          .withLastModifiedBy(id('shr.test', 'A')))
+    );
+  });
+
+  // Valid Decimal Constraints
+
+  it('should allow a fixed integer constraint to apply to decimal values', () => {
+    let a = new models.DataElement(id('shr.test', 'A'), true)
+      .withValue(new models.IdentifiableValue(pid('decimal')).withMinMax(0, 1)
+      .withConstraint(new models.FixedValueConstraint(123, 'integer')));
+    
+    add(a);
+    doExpand();
+
+    expect(err.hasErrors()).to.be.false;
+    const A = findExpanded('shr.test', 'A');
+    expect(A.identifier).to.eql(id('shr.test', 'A'));
+    expect(A.value).to.eql(
+      new models.IdentifiableValue(pid('decimal')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint(123, 'decimal')
+          .withLastModifiedBy(id('shr.test', 'A')))
+    );
+  });
+
   it('should properly deal with inherited TBD values', () => {
     let a = new models.DataElement(id('shr.test', 'A'), true)
       .withValue(new models.TBD('Not ready yet!')

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,10 +895,10 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.2.0.tgz#1f66f3bc8a16c15328607e5b05a99cf7a3bc53fe"
-  integrity sha512-h7u7PpKuxd5epy+cMHzjnGAesPo/GmtQnUjeZHMuIfoNzJ82mrvMpZ8P3EdiKLD+y12nMzCX54wg8iAjDmzO5g==
+shr-models@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.3.0.tgz#7fee7a76c700c4dc3598c7465529e17048b5bf8f"
+  integrity sha512-SyUHKzOAAmMgLm/N7lnA2SWvLnjqfYQV33+ywryFUQEktB05VohnHxTkfgGfyi8mjUyqAKE51hDr58QU7kDzZA==
 
 shr-test-helpers@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Modified `supportsFixedValueConstraint` function to work for integers, decimals, URIs. It now allows certain conversions.
* `string` constraint can apply to both `string` and `uri` primitive types
* `int` constraint can apply to `decimal` primitive types