### PR TITLE
Support direct reference of includes types in mapping sourcepaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-expand",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Expands SHR data elements to copy down fields from data elements they're based on and consolidates their constraints; does similar for mappings.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Due to legacy reasons for how includes types are represented in paths in SHR FHIR export, the way you reference them in the mapping file is *different* than how you might reference them in a data elements file.

In short, you replace the original identifier with the new includes type identifier.  For example, if in your definition you had:

```
Components.ObservationComponent
  includes 0..1 SystolicPressure
  includes 0..1 DiastolicPressure
```

You would reference those in mappings as:

```
Components.SystolicPressure maps to ...
Components.DiastolicPressure maps to ...
```

This works with a corresponding branch / PR on `shr-fhir-export` and the `bp_component_mapping` branch of `shr_spec`.