### PR TITLE
Value to subclass choice

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -525,7 +525,7 @@ class Expander {
       let oldChoiceValue = oldValue.clone();
       if (oldChoiceValue instanceof models.IdentifiableValue) {
         // To simplify the code, we just turn the non-choice to a choice of 1 and proceed
-        oldChoiceValue = new models.ChoiceValue().withCard(oldChoiceValue.card).withOption(oldChoiceValue.withCard(undefined));
+        oldChoiceValue = new models.ChoiceValue().withCard(oldChoiceValue.card).withOption(oldChoiceValue);
       } else if (!(oldValue instanceof models.ChoiceValue)) {
         logger.error('Cannot override %s with %s since overriding a simple value with a choice value is not supported. ERROR_CODE:12008', oldValue.toString(), newValue.toString());
         return mergedValue;

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -837,13 +837,13 @@ describe('#expand()', () => {
           .withConstraint(
             new models.TypeConstraint(id('shr.test', 'SubA'), [], false)
               .withLastModifiedBy(id('shr.test', 'SubX'))
-          )
+          ).withMinMax(0, 1)
         )
         .withOption(new models.IdentifiableValue(id('shr.test', 'A'))
           .withConstraint(
             new models.TypeConstraint(id('shr.test', 'SubA2'), [], false)
               .withLastModifiedBy(id('shr.test', 'SubX'))
-          )
+          ).withMinMax(0, 1)
         )
         .withInheritance(models.OVERRIDDEN)
         .withInheritedFrom(x.identifier)


### PR DESCRIPTION
This allows for a value to be converted into a choice of its subclasses. Here is an example of the desired behavior that is now allowed.
```
Element: Bar 
Value: Foo // this is the element we want to constrain

Element: BarConstrainedValue 
Parent: Bar 
Value only FooSubclass1 or FooSubclass2 // this is now supported 

//-----Supporting definitions ---- 
Element: Foo
Value: concept

Element: FooSubclass1
Parent: Foo

Element: FooSubclass2
Parent: Foo

```