### PR TITLE
Fixed date and dateTime

### DIFF
--- a/errorMessages.txt
+++ b/errorMessages.txt
@@ -51,4 +51,5 @@ Number, Message, Solution, deduplicationKeys
 12047, 'Cannot resolve target of card constraint on ${target1} ',  'Unknown', 'errorNumber'
 12048, 'Invalid constraint path: ${target1}',  'Unknown', 'errorNumber'
 12049, 'Cannot determine target item of mapping for ${identifier1}',  'Unknown', 'errorNumber'
+12050, 'Invalid format for ${type} with value ${value}', 'Unknown', 'errorNumber'
 

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -20,7 +20,7 @@ const BOOLEAN = new models.PrimitiveIdentifier('boolean');
 // For example, string constraint can be used on value of type uri.
 const constraintConversions = {
   'integer': ['decimal'],
-  'string': ['uri', 'date', 'dateTime']
+  'string': ['uri', 'date', 'dateTime', 'instant', 'time']
 }
 
 class Expander {
@@ -1233,14 +1233,19 @@ class Expander {
 
   checkDateFormat(constraint) {
     let validFormat;
+    // Regex expressions from https://www.hl7.org/fhir/datatypes.html
     if (constraint.type === 'date') {
-      // Regex from https://www.hl7.org/fhir/datatypes.html
       // Checks if date is of form YYYY, YYYY-MM, or YYYY-MM-DD
       validFormat = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$/.test(constraint.value);
     } else if (constraint.type === 'dateTime') {
-      // Regex from https://www.hl7.org/fhir/datatypes.html
       // Checks if dateTime is of form YYYY, YYYY-MM, YYYY-MM-DD, or YYYY-MM-DDThh:mm:ss+zz:zz
       validFormat = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/.test(constraint.value);
+    } else if (constraint.type === 'instant') {
+      // Checks if instant is of the form YYYY-MM-DDThh:mm:ss+zz:zz (specified to at least second, must include time zone)
+      validFormat = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))$/.test(constraint.value);
+    } else if (constraint.type === 'time') {
+      // Checks if time is of the form hh:mm:ss (specified to second, but seconds can be 0 filled)
+      validFormat = /^([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?$/.test(constraint.value);
     }
     if (!validFormat) {
       logger.error('Invalid format for %s with value %s.  ERROR_CODE:12043', constraint.type, constraint.value);
@@ -1254,7 +1259,7 @@ class Expander {
       (constraintConversions[constraint.type] && constraintConversions[constraint.type].includes(identifier.name)))) {
       // reset constraint.type in case they are not equal, but identifier.name is allowed conversion
       constraint.type = identifier.name;
-      if (constraint.type === 'date' || constraint.type === 'dateTime') {
+      if (['date', 'dateTime', 'instant', 'time'].indexOf(constraint.type) > -1) {
         return this.checkDateFormat(constraint);
       }
       return true;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1234,8 +1234,12 @@ class Expander {
   checkDateFormat(constraint) {
     let validFormat;
     if (constraint.type === 'date') {
+      // Regex from https://www.hl7.org/fhir/datatypes.html
+      // Checks if date is of form YYYY, YYYY-MM, or YYYY-MM-DD
       validFormat = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$/.test(constraint.value);
     } else if (constraint.type === 'dateTime') {
+      // Regex from https://www.hl7.org/fhir/datatypes.html
+      // Checks if dateTime is of form YYYY, YYYY-MM, YYYY-MM-DD, or YYYY-MM-DDThh:mm:ss+zz:zz
       validFormat = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/.test(constraint.value);
     }
     if (!validFormat) {

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -20,7 +20,7 @@ const BOOLEAN = new models.PrimitiveIdentifier('boolean');
 // For example, string constraint can be used on value of type uri.
 const constraintConversions = {
   'integer': ['decimal'],
-  'string': ['uri']
+  'string': ['uri', 'date', 'dateTime']
 }
 
 class Expander {
@@ -1231,12 +1231,28 @@ class Expander {
     return BOOLEAN.equals(identifier);
   }
 
+  checkDateFormat(constraint) {
+    let validFormat;
+    if (constraint.type === 'date') {
+      validFormat = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?$/.test(constraint.value);
+    } else if (constraint.type === 'dateTime') {
+      validFormat = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/.test(constraint.value);
+    }
+    if (!validFormat) {
+      logger.error('Invalid format for %s with value %s.  ERROR_CODE:12043', constraint.type, constraint.value);
+    }
+    return validFormat;
+  }
+
   supportsFixedValueConstraint(identifier, constraint) {
     if (identifier && constraint && 
       (identifier.name === constraint.type || 
       (constraintConversions[constraint.type] && constraintConversions[constraint.type].includes(identifier.name)))) {
       // reset constraint.type in case they are not equal, but identifier.name is allowed conversion
       constraint.type = identifier.name;
+      if (constraint.type === 'date' || constraint.type === 'dateTime') {
+        return this.checkDateFormat(constraint);
+      }
       return true;
     }
     return false;

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1248,7 +1248,8 @@ class Expander {
       validFormat = /^([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?$/.test(constraint.value);
     }
     if (!validFormat) {
-      logger.error('Invalid format for %s with value %s.  ERROR_CODE:12043', constraint.type, constraint.value);
+      // 12050, 'Invalid format for ${type} with value ${value}', 'Unknown', 'errorNumber'
+      logger.error({type: constraint.type, value: constraint.value}, '12050');
     }
     return validFormat;
   }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -1094,7 +1094,7 @@ class Expander {
           valID = valOption.identifier;
         }
       }
-      if (!this.supportsFixedValueConstraint(valID, constraint)) {
+      if (!this.supportsFixedValueConstraint(valID, constraint) && ['date', 'dateTime', 'instant', 'time'].indexOf(constraint.type) < 0) {
         // 12041, 'Cannot constrain value of ${target} to ${type} since neither it nor its value is a ${type}', 'Unknown', 'errorNumber'
         logger.error({target: targetLabel, type: constraint.type}, '12041');
         return previousConstraints;

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -3478,6 +3478,77 @@ describe('#expand()', () => {
     );
   });
 
+  // Valid date Constraints
+
+  it('should allow a fixed date constraint to apply to date values', () => {
+    let a = new models.DataElement(id('shr.test', 'A'), true)
+      .withValue(new models.IdentifiableValue(pid('date')).withMinMax(0, 1)
+      .withConstraint(new models.FixedValueConstraint('2019-09-03', 'date')));
+    let b = new models.DataElement(id('shr.test', 'B'), true)
+      .withValue(new models.IdentifiableValue(pid('date')).withMinMax(0, 1)
+      .withConstraint(new models.FixedValueConstraint('2019-09', 'date')));
+    let c = new models.DataElement(id('shr.test', 'C'), true)
+      .withValue(new models.IdentifiableValue(pid('date')).withMinMax(0, 1)
+      .withConstraint(new models.FixedValueConstraint('2019', 'date')));
+    
+    add(a, b, c);
+    doExpand();
+
+    expect(err.hasErrors()).to.be.false;
+    const A = findExpanded('shr.test', 'A');
+    expect(A.identifier).to.eql(id('shr.test', 'A'));
+    expect(A.value).to.eql(
+      new models.IdentifiableValue(pid('date')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('2019-09-03', 'date')
+          .withLastModifiedBy(id('shr.test', 'A')))
+    );
+    const B = findExpanded('shr.test', 'B');
+    expect(B.identifier).to.eql(id('shr.test', 'B'));
+    expect(B.value).to.eql(
+      new models.IdentifiableValue(pid('date')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('2019-09', 'date')
+          .withLastModifiedBy(id('shr.test', 'B')))
+    );
+    const C = findExpanded('shr.test', 'C');
+    expect(C.identifier).to.eql(id('shr.test', 'C'));
+    expect(C.value).to.eql(
+      new models.IdentifiableValue(pid('date')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('2019', 'date')
+          .withLastModifiedBy(id('shr.test', 'C')))
+    );
+  });
+
+  // Valid dateTime Constraints
+
+  it('should allow a fixed dateTime constraint to apply to dateTime values', () => {
+    let a = new models.DataElement(id('shr.test', 'A'), true)
+      .withValue(new models.IdentifiableValue(pid('dateTime')).withMinMax(0, 1)
+      .withConstraint(new models.FixedValueConstraint('2019-09-03', 'dateTime')));
+    let b = new models.DataElement(id('shr.test', 'B'), true)
+      .withValue(new models.IdentifiableValue(pid('dateTime')).withMinMax(0, 1)
+      .withConstraint(new models.FixedValueConstraint('2019-09-03T12:34:56Z', 'dateTime')));
+    
+    add(a, b);
+    doExpand();
+
+    expect(err.hasErrors()).to.be.false;
+    const A = findExpanded('shr.test', 'A');
+    expect(A.identifier).to.eql(id('shr.test', 'A'));
+    expect(A.value).to.eql(
+      new models.IdentifiableValue(pid('dateTime')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('2019-09-03', 'dateTime')
+          .withLastModifiedBy(id('shr.test', 'A')))
+    );
+    const B = findExpanded('shr.test', 'B');
+    expect(B.identifier).to.eql(id('shr.test', 'B'));
+    expect(B.value).to.eql(
+      new models.IdentifiableValue(pid('dateTime')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('2019-09-03T12:34:56Z', 'dateTime')
+          .withLastModifiedBy(id('shr.test', 'B')))
+    );
+  });
+
+
   it('should properly deal with inherited TBD values', () => {
     let a = new models.DataElement(id('shr.test', 'A'), true)
       .withValue(new models.TBD('Not ready yet!')

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -3548,6 +3548,46 @@ describe('#expand()', () => {
     );
   });
 
+    // Valid instant Constraints
+
+    it('should allow a fixed instant constraint to apply to instant values', () => {
+      let a = new models.DataElement(id('shr.test', 'A'), true)
+        .withValue(new models.IdentifiableValue(pid('instant')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('2019-09-03T12:34:56Z', 'instant')));
+      
+      add(a);
+      doExpand();
+  
+      expect(err.hasErrors()).to.be.false;
+      const A = findExpanded('shr.test', 'A');
+      expect(A.identifier).to.eql(id('shr.test', 'A'));
+      expect(A.value).to.eql(
+        new models.IdentifiableValue(pid('instant')).withMinMax(0, 1)
+          .withConstraint(new models.FixedValueConstraint('2019-09-03T12:34:56Z', 'instant')
+            .withLastModifiedBy(id('shr.test', 'A')))
+      );
+    });
+
+    // Valid time Constraints
+
+    it('should allow a fixed time constraint to apply to time values', () => {
+      let a = new models.DataElement(id('shr.test', 'A'), true)
+        .withValue(new models.IdentifiableValue(pid('time')).withMinMax(0, 1)
+        .withConstraint(new models.FixedValueConstraint('12:34:56', 'time')));
+      
+      add(a);
+      doExpand();
+  
+      expect(err.hasErrors()).to.be.false;
+      const A = findExpanded('shr.test', 'A');
+      expect(A.identifier).to.eql(id('shr.test', 'A'));
+      expect(A.value).to.eql(
+        new models.IdentifiableValue(pid('time')).withMinMax(0, 1)
+          .withConstraint(new models.FixedValueConstraint('12:34:56', 'time')
+            .withLastModifiedBy(id('shr.test', 'A')))
+      );
+    });
+
 
   it('should properly deal with inherited TBD values', () => {
     let a = new models.DataElement(id('shr.test', 'A'), true)


### PR DESCRIPTION
Adds support for fixing `date` and `dateTime` values. The constraint uses the grammar for fixing a string as shown here:
```
Element:    DateElement
Value:      date = "1996-11-22"
```
The format of the `date` or `dateTime` is validated to conform to FHIR specifications. This PR also adds tests of valid `date` or `dateTime` constraints. Note that the `dateTime` value shown in the IG gets converted to your computer's set time zone when building. This behavior is from the IG publisher tool, not our tooling.