### PR TITLE
Add SubsetConstraint

### DIFF
--- a/lib/expand.js
+++ b/lib/expand.js
@@ -739,22 +739,19 @@ class Expander {
       logger.error('Cannot constrain type of %s since it has no identifier. ERROR_CODE:12013', targetLabel);
       return constraints;
     } 
-    // else if (!this.checkHasBaseType(constraint.isA, target.identifier)) {
-    //   logger.error('Cannot constrain type of %s to %s. ERROR_CODE:12014', targetLabel, constraint.isA.toString());
-    //   return constraints;
-    // }
     const filtered = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).subset.constraints;
-    // for (const previous of filtered) {
-    //   if (constraint.onValue != previous.onValue) {
-    //     continue;
-    //   }
-    //   if (!this.checkHasBaseType(constraint.isA, previous.isA)) {
-    //     logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toString(), previous.isA.toString(), constraint.isA.toString());
-    //     return constraints;
-    //   }
-    //   // Remove the previous type constraint since this one supercedes it
-    //   constraints = constraints.filter(cst => cst !== previous);
-    // }
+    for (const previous of filtered) {
+      if (constraint.onValue != previous.onValue) {
+        continue;
+      }
+      const subsetContained = constraint.subsetList.every(tCurrent => {
+        return previous.subsetList.some(tPrevious => this.checkHasBaseType(tCurrent, tPrevious));   
+      });
+      if (!subsetContained) {
+        logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toString(), previous.subsetList, constraint.subsetList);
+      }
+      constraints = constraints.filter(cst => cst !== previous);
+    }
     constraints.push(constraint);
     return constraints;
   }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -700,7 +700,6 @@ class Expander {
   consolidateSubsetConstraint(element, value, constraint, previousConstraints) {
     constraint = constraint.clone();
     // If the constraint is actually on the target's value, update the path to explicitly include the target's value
-    let skipCheck = false;
     if (constraint.onValue) {
       const targetVal = this.constraintTargetValue(value, constraint.path);
       // If it's a choice, check if the constraint is the choice or a subtype of the choice
@@ -714,36 +713,19 @@ class Expander {
           logger.error('Cannot constrain type of %s to %s. ERROR_CODE:12012', targetLabel, constraint.subsetList);
           return previousConstraints;
         }
-        skipCheck = true; // We already checked it
-      } else {
-        // It's an identifier, so rewrite the constraint to be more specific
-        const valID = this.constraintTargetValueIdentifier(value, constraint.path);
-        if (valID) {
-          constraint.onValue = false;
-          constraint.path.push(valID);
-        } else {
-          const targetLabel = this.constraintTargetLabel(value, constraint.path);
-          logger.error('Cannot resolve target of value type constraint on %s.  ERROR_CODE:12039', targetLabel);
-          return previousConstraints;
-        }
       }
     }
 
     const target = this.constraintTarget(value, constraint.path);
-    const targetLabel = this.constraintTargetLabel(value, constraint.path);
 
     let constraints = previousConstraints;
-    if (skipCheck) {
-      // It's a choice, we already checked it
-    } else if (!(target instanceof models.IdentifiableValue)) {
-      logger.error('Cannot constrain type of %s since it has no identifier. ERROR_CODE:12013', targetLabel);
-      return constraints;
-    } 
     const filtered = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).subset.constraints;
     for (const previous of filtered) {
       if (constraint.onValue != previous.onValue) {
         continue;
       }
+      // Check if the each element of the new subset has some base type in the previous subset
+      // Does allow elements in previous subset to serve as base type for multiple elements in new subset
       const subsetContained = constraint.subsetList.every(tCurrent => {
         return previous.subsetList.some(tPrevious => this.checkHasBaseType(tCurrent, tPrevious));   
       });

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -573,6 +573,8 @@ class Expander {
         consolidateFn = this.consolidateCardConstraint;
       } else if (constraint instanceof models.TypeConstraint) {
         consolidateFn = this.consolidateTypeConstraint;
+      } else if (constraint instanceof models.SubsetConstraint) {
+        consolidateFn = this.consolidateSubsetConstraint;
       } else if (constraint instanceof models.IncludesTypeConstraint) {
         consolidateFn = this.consolidateIncludesTypeConstraint;
       } else if (constraint instanceof models.ValueSetConstraint) {
@@ -691,6 +693,68 @@ class Expander {
       // Remove the previous type constraint since this one supercedes it
       constraints = constraints.filter(cst => cst !== previous);
     }
+    constraints.push(constraint);
+    return constraints;
+  }
+
+  consolidateSubsetConstraint(element, value, constraint, previousConstraints) {
+    constraint = constraint.clone();
+    // If the constraint is actually on the target's value, update the path to explicitly include the target's value
+    let skipCheck = false;
+    if (constraint.onValue) {
+      const targetVal = this.constraintTargetValue(value, constraint.path);
+      // If it's a choice, check if the constraint is the choice or a subtype of the choice
+      if (targetVal instanceof models.ChoiceValue) {
+        const optionIdentifiers = targetVal.aggregateOptions.map(opt => opt.identifier);
+        const areValidOptions = constraint.subsetList.every(elem => {
+          return optionIdentifiers.some(optId => optId.equals(elem));
+        });
+        if (!areValidOptions) {
+          const targetLabel = this.constraintTargetLabel(value, constraint.path);
+          logger.error('Cannot constrain type of %s to %s. ERROR_CODE:12012', targetLabel, constraint.subsetList);
+          return previousConstraints;
+        }
+        skipCheck = true; // We already checked it
+      } else {
+        // It's an identifier, so rewrite the constraint to be more specific
+        const valID = this.constraintTargetValueIdentifier(value, constraint.path);
+        if (valID) {
+          constraint.onValue = false;
+          constraint.path.push(valID);
+        } else {
+          const targetLabel = this.constraintTargetLabel(value, constraint.path);
+          logger.error('Cannot resolve target of value type constraint on %s.  ERROR_CODE:12039', targetLabel);
+          return previousConstraints;
+        }
+      }
+    }
+
+    const target = this.constraintTarget(value, constraint.path);
+    const targetLabel = this.constraintTargetLabel(value, constraint.path);
+
+    let constraints = previousConstraints;
+    if (skipCheck) {
+      // It's a choice, we already checked it
+    } else if (!(target instanceof models.IdentifiableValue)) {
+      logger.error('Cannot constrain type of %s since it has no identifier. ERROR_CODE:12013', targetLabel);
+      return constraints;
+    } 
+    // else if (!this.checkHasBaseType(constraint.isA, target.identifier)) {
+    //   logger.error('Cannot constrain type of %s to %s. ERROR_CODE:12014', targetLabel, constraint.isA.toString());
+    //   return constraints;
+    // }
+    const filtered = (new models.ConstraintsFilter(previousConstraints)).withPath(constraint.path).subset.constraints;
+    // for (const previous of filtered) {
+    //   if (constraint.onValue != previous.onValue) {
+    //     continue;
+    //   }
+    //   if (!this.checkHasBaseType(constraint.isA, previous.isA)) {
+    //     logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toString(), previous.isA.toString(), constraint.isA.toString());
+    //     return constraints;
+    //   }
+    //   // Remove the previous type constraint since this one supercedes it
+    //   constraints = constraints.filter(cst => cst !== previous);
+    // }
     constraints.push(constraint);
     return constraints;
   }

--- a/lib/expand.js
+++ b/lib/expand.js
@@ -699,18 +699,20 @@ class Expander {
 
   consolidateSubsetConstraint(element, value, constraint, previousConstraints) {
     constraint = constraint.clone();
-    // If the constraint is actually on the target's value, update the path to explicitly include the target's value
     if (constraint.onValue) {
       const targetVal = this.constraintTargetValue(value, constraint.path);
       // If it's a choice, check if the constraint is the choice or a subtype of the choice
       if (targetVal instanceof models.ChoiceValue) {
         const optionIdentifiers = targetVal.aggregateOptions.map(opt => opt.identifier);
+        // Every type in subset must equal or be child of the original choices
         const areValidOptions = constraint.subsetList.every(elem => {
-          return optionIdentifiers.some(optId => optId.equals(elem));
+          return optionIdentifiers.some(optId => this.checkHasBaseType(elem, optId));
         });
         if (!areValidOptions) {
           const targetLabel = this.constraintTargetLabel(value, constraint.path);
-          logger.error('Cannot constrain type of %s to %s. ERROR_CODE:12012', targetLabel, constraint.subsetList);
+          const types = constraint.subsetList.map(sub => sub.name);
+          //12012 , 'Cannot constrain type of ${name1} to ${type1}' , 'Make sure base types match', 'errorNumber'
+          logger.error({name1 : targetLabel, type1 : types}, '12012');
           return previousConstraints;
         }
       }
@@ -730,7 +732,10 @@ class Expander {
         return previous.subsetList.some(tPrevious => this.checkHasBaseType(tCurrent, tPrevious));   
       });
       if (!subsetContained) {
-        logger.error('Cannot further constrain type of %s from %s to %s. ERROR_CODE:12015', target.toString(), previous.subsetList, constraint.subsetList);
+        const types1 = previous.subsetList.map(sub => sub.name);
+        const types2 = constraint.subsetList.map(sub => sub.name);
+        //12015 , 'Cannot further constrain type of ${name1} from ${type1} to ${type2} The two elements aren't based on the same parent. You cannot constrain an element to one that is completely distinct.' , 'Unknown' , 'errorNumber'
+        logger.error({name1 : target.toString(), type1 : types1, type2 : types2},'12015' );
       }
       constraints = constraints.filter(cst => cst !== previous);
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "^6.6.0",
+    "shr-models": "standardhealth/shr-models#add-subset-constraint",
     "shr-test-helpers": "^6.0.0"
   },
   "peerDependencies": {

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -1486,6 +1486,118 @@ describe('#expand()', () => {
     expect(eSubX.fields).to.be.empty;
   });
 
+  // Valid Subset Constraints
+
+  it ('should allow subset constraints to narrow a choice to multiple options', function () {
+    let a = new models.DataElement(id('shr.test', 'A'), true);
+    let b = new models.DataElement(id('shr.test', 'B'), true);
+    let c = new models.DataElement(id('shr.test', 'C'), true);
+    let x = new models.DataElement(id('shr.test', 'X'), true)
+      .withValue(
+        new models.ChoiceValue().withMinMax(0, 1)
+          .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
+          .withOption(new models.IdentifiableValue(id('shr.test', 'B')))
+          .withOption(new models.IdentifiableValue(id('shr.test', 'C')))
+      );
+    let y = new models.DataElement(id('shr.test', 'Y'), true)
+      .withValue(
+        new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
+          .withConstraint(new models.SubsetConstraint([id('shr.test', 'B'), id('shr.test', 'C')]).withOnValue(true))
+      );
+    add(a, b, c, x, y);
+    
+    doExpand();
+
+    expect(err.hasErrors()).to.be.false;
+    const eY = findExpanded('shr.test', 'Y');
+    expect(eY.identifier).to.eql(id('shr.test', 'Y'));
+    expect(eY.value).to.eql(
+      new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
+        .withConstraint(new models.SubsetConstraint([id('shr.test', 'B'), id('shr.test', 'C')]).withOnValue(true).withLastModifiedBy(id('shr.test', 'Y')))
+    );
+    expect(eY.fields).to.be.empty;
+  });
+
+  it ('should allow subset constraints to narrow a choice on a field to multiple options', function() {
+    let a = new models.DataElement(id('shr.test', 'A'), true);
+    let b = new models.DataElement(id('shr.test', 'B'), true);
+    let c = new models.DataElement(id('shr.test', 'C'), true);
+    let x = new models.DataElement(id('shr.test', 'X'), true)
+      .withValue(
+        new models.ChoiceValue().withMinMax(0, 1)
+          .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
+          .withOption(new models.IdentifiableValue(id('shr.test', 'B')))
+          .withOption(new models.IdentifiableValue(id('shr.test', 'C')))
+      );
+    let y = new models.DataElement(id('shr.test', 'Y'), true)
+      .withField(
+        new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
+          .withConstraint(new models.SubsetConstraint([id('shr.test', 'B'), id('shr.test', 'C')]).withOnValue(true))
+      );
+    add(a, b, c, x, y);
+    
+    doExpand();
+
+    expect(err.hasErrors()).to.be.false;
+    const eY = findExpanded('shr.test', 'Y');
+    expect(eY.identifier).to.eql(id('shr.test', 'Y'));
+    expect(eY.fields).to.eql([
+      new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
+        .withConstraint(new models.SubsetConstraint([id('shr.test', 'B'), id('shr.test', 'C')]).withOnValue(true).withLastModifiedBy(id('shr.test', 'Y')))
+    ]);
+  });
+
+  it('should allow subset constraints to narrow a choice to primitive types to multiple options', function() {
+    let a = new models.DataElement(id('shr.test', 'A'), true);
+    let x = new models.DataElement(id('shr.test', 'X'), true)
+      .withValue(
+        new models.ChoiceValue().withMinMax(0, 1)
+          .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
+          .withOption(new models.IdentifiableValue(pid('string')))
+          .withOption(new models.IdentifiableValue(pid('integer')))
+      );
+    let y = new models.DataElement(id('shr.test', 'Y'), true)
+      .withValue(
+        new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
+          .withConstraint(new models.SubsetConstraint([pid('string'), pid('integer')]).withOnValue(true))
+      );
+    add(a, x, y);
+
+    doExpand();
+
+    expect(err.errors()).to.deep.equal([]);
+    const eY = findExpanded('shr.test', 'Y');
+    expect(eY.identifier).to.eql(id('shr.test', 'Y'));
+    expect(eY.value).to.eql(
+      new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
+        .withConstraint(new models.SubsetConstraint([pid('string'), pid('integer')]).withOnValue(true).withLastModifiedBy(id('shr.test', 'Y')))
+    );
+    expect(eY.fields).to.be.empty;
+  });
+
+  // Invalid Subset Constraints
+  it('should report an error when constraining subset is not contained in original choices', function() {
+    let a = new models.DataElement(id('shr.test', 'A'), true);
+    let x = new models.DataElement(id('shr.test', 'X'), true)
+      .withValue(
+        new models.ChoiceValue().withMinMax(0, 1)
+          .withOption(new models.IdentifiableValue(id('shr.test', 'A')))
+          .withOption(new models.IdentifiableValue(pid('string')))
+          .withOption(new models.IdentifiableValue(pid('integer')))
+      );
+    let y = new models.DataElement(id('shr.test', 'Y'), true)
+      .withValue(
+        new models.IdentifiableValue(id('shr.test', 'X')).withMinMax(0, 1)
+          .withConstraint(new models.SubsetConstraint([pid('decimal'), pid('integer')]).withOnValue(true))
+      );
+    add(a, x, y);
+
+    doExpand();
+
+    expect(err.errors()).to.have.length(1);
+    expect(err.errors()[0].msg).to.contain('type').and.to.contain('decimal');
+  });
+
   // Valid Includes Type Constraints
 
   it('should keep valid includes type constraints on values', () => {

--- a/test/expand-test.js
+++ b/test/expand-test.js
@@ -1595,7 +1595,8 @@ describe('#expand()', () => {
     doExpand();
 
     expect(err.errors()).to.have.length(1);
-    expect(err.errors()[0].msg).to.contain('type').and.to.contain('decimal');
+    expect(err.errors()[0].msg).to.eql('12012');
+    expect(err.errors()[0].name1).to.eql('X');
   });
 
   // Valid Includes Type Constraints

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,10 +895,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^6.6.0:
+shr-models@standardhealth/shr-models#add-subset-constraint:
   version "6.6.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.6.0.tgz#5d58d01d58f1adf500c8129b1510f69cccce1dbc"
-  integrity sha512-OMnpOdJN61Gr9abzveIZrfxQQoi2CLHbeFOfzgcahiX1ERZ+tQOqxLFvc0vrB3js9yQewmCZVH9w11pHSp6PTQ==
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/d04a6807ca61eae332e29d92477ca4d17c67c4a2"
 
 shr-test-helpers@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This adds support for processing `SubsetConstraint`s and adds tests of this processing.
This PR is 4/7. These PRs impact:
* `shr-grammar` https://github.com/standardhealth/shr-grammar/pull/46
* `shr-text-import` https://github.com/standardhealth/shr-text-import/pull/108
* `shr-models` https://github.com/standardhealth/shr-models/pull/47
* `shr-expand`
* `shr-fhir-export` https://github.com/standardhealth/shr-fhir-export/pull/161
* `shr-json-schema-export` https://github.com/standardhealth/shr-json-schema-export/pull/16
* `shr-json-javadoc` https://github.com/standardhealth/shr-json-javadoc/pull/29